### PR TITLE
Implemented background colors for text

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/skin/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/skin/ParagraphText.java
@@ -183,9 +183,9 @@ class ParagraphText<S> extends TextFlowExt {
             int end = start + text.getText().length();
 
             // Set fill
-            Paint[] paints = text.backgroundColorProperty().get();
-            if (paints != null && paints.length > 0) {
-                backgroundShape.setFill(paints[0]);
+            Paint paint = text.backgroundFillProperty().get();
+            if (paint != null) {
+                backgroundShape.setFill(paint);
 
                 // Set path elements
                 PathElement[] shape = getRangeShape(start, end);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/skin/TextExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/skin/TextExt.java
@@ -1,0 +1,95 @@
+package org.fxmisc.richtext.skin;
+
+import com.sun.javafx.css.converters.PaintConverter;
+import javafx.beans.property.ObjectProperty;
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
+import javafx.scene.text.Text;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TextExt extends Text {
+
+    private ObjectProperty<Paint[]> backgroundColor = null;
+
+    public TextExt(String text) {
+        super(text);
+    }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        try {
+            // Get inner class
+            Class<?> clazz = Class.forName("javafx.scene.text.Text$StyleableProperties");
+
+            // Get field and make it accessible
+            Field styleablesField = clazz.getDeclaredField("STYLEABLES");
+            styleablesField.setAccessible(true);
+
+            // Get list value and make it modifiable
+            List<CssMetaData<? extends Styleable, ?>> styleables = (List<CssMetaData<? extends Styleable, ?>>) styleablesField.get(null);
+            styleables = new ArrayList<>(styleables);
+
+            // Add new properties
+            styleables.add(StyleableProperties.BACKGROUND_COLOR);
+
+            // Set list value
+            return styleables;
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public ObjectProperty<Paint[]> backgroundColorProperty() {
+        if (backgroundColor == null) {
+            backgroundColor = new StyleableObjectProperty<Paint[]>(null) {
+                @Override
+                public Object getBean() {
+                    return TextExt.this;
+                }
+
+                @Override
+                public String getName() {
+                    return "backgroundColor";
+                }
+
+                @Override
+                public CssMetaData<TextExt, Paint[]> getCssMetaData() {
+                    return StyleableProperties.BACKGROUND_COLOR;
+                }
+
+                @Override
+                public void invalidated() {
+                    // TODO
+                }
+            };
+        }
+        return backgroundColor;
+    }
+
+    private static class StyleableProperties {
+
+        private static final CssMetaData<TextExt, Paint[]> BACKGROUND_COLOR = new CssMetaData<TextExt, Paint[]>(
+                "-fx-background-color",
+                PaintConverter.SequenceConverter.getInstance(),
+                new Paint[]{Color.TRANSPARENT}) {
+            @Override
+            public boolean isSettable(TextExt node) {
+                return node.backgroundColor == null || !node.backgroundColor.isBound();
+            }
+
+            @Override
+            public StyleableProperty<Paint[]> getStyleableProperty(TextExt node) {
+                return (StyleableProperty<Paint[]>) node.backgroundColorProperty();
+            }
+        };
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/skin/TextExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/skin/TextExt.java
@@ -10,7 +10,6 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.text.Text;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,28 +23,22 @@ public class TextExt extends Text {
 
     @Override
     public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
-        try {
-            // Get inner class
-            Class<?> clazz = Class.forName("javafx.scene.text.Text$StyleableProperties");
+        // Get list value and make it modifiable
+        List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(super.getCssMetaData());
 
-            // Get field and make it accessible
-            Field styleablesField = clazz.getDeclaredField("STYLEABLES");
-            styleablesField.setAccessible(true);
+        // Add new properties
+        styleables.add(StyleableProperties.BACKGROUND_COLOR);
 
-            // Get list value and make it modifiable
-            List<CssMetaData<? extends Styleable, ?>> styleables = (List<CssMetaData<? extends Styleable, ?>>) styleablesField.get(null);
-            styleables = new ArrayList<>(styleables);
+        // Return list value
+        return styleables;
+    }
 
-            // Add new properties
-            styleables.add(StyleableProperties.BACKGROUND_COLOR);
+    public Paint[] getBackgroundColor() {
+        return backgroundColor.get();
+    }
 
-            // Set list value
-            return styleables;
-        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
-        }
-
-        return null;
+    public void setBackgroundColor(Paint[] backgroundColor) {
+        this.backgroundColor.set(backgroundColor);
     }
 
     public ObjectProperty<Paint[]> backgroundColorProperty() {
@@ -64,11 +57,6 @@ public class TextExt extends Text {
                 @Override
                 public CssMetaData<TextExt, Paint[]> getCssMetaData() {
                     return StyleableProperties.BACKGROUND_COLOR;
-                }
-
-                @Override
-                public void invalidated() {
-                    // TODO
                 }
             };
         }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/skin/TextExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/skin/TextExt.java
@@ -1,11 +1,7 @@
 package org.fxmisc.richtext.skin;
 
-import com.sun.javafx.css.converters.PaintConverter;
 import javafx.beans.property.ObjectProperty;
-import javafx.css.CssMetaData;
-import javafx.css.Styleable;
-import javafx.css.StyleableObjectProperty;
-import javafx.css.StyleableProperty;
+import javafx.css.*;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.text.Text;
@@ -15,7 +11,7 @@ import java.util.List;
 
 public class TextExt extends Text {
 
-    private ObjectProperty<Paint[]> backgroundColor = null;
+    private ObjectProperty<Paint> backgroundFill = null;
 
     public TextExt(String text) {
         super(text);
@@ -27,23 +23,23 @@ public class TextExt extends Text {
         List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(super.getCssMetaData());
 
         // Add new properties
-        styleables.add(StyleableProperties.BACKGROUND_COLOR);
+        styleables.add(StyleableProperties.BACKGROUND_FILL);
 
         // Return list value
         return styleables;
     }
 
-    public Paint[] getBackgroundColor() {
-        return backgroundColor.get();
+    public Paint getBackgroundFill() {
+        return backgroundFill.get();
     }
 
-    public void setBackgroundColor(Paint[] backgroundColor) {
-        this.backgroundColor.set(backgroundColor);
+    public void setBackgroundFill(Paint backgroundFill) {
+        this.backgroundFill.set(backgroundFill);
     }
 
-    public ObjectProperty<Paint[]> backgroundColorProperty() {
-        if (backgroundColor == null) {
-            backgroundColor = new StyleableObjectProperty<Paint[]>(null) {
+    public ObjectProperty<Paint> backgroundFillProperty() {
+        if (backgroundFill == null) {
+            backgroundFill = new StyleableObjectProperty<Paint>(null) {
                 @Override
                 public Object getBean() {
                     return TextExt.this;
@@ -51,32 +47,32 @@ public class TextExt extends Text {
 
                 @Override
                 public String getName() {
-                    return "backgroundColor";
+                    return "backgroundFill";
                 }
 
                 @Override
-                public CssMetaData<TextExt, Paint[]> getCssMetaData() {
-                    return StyleableProperties.BACKGROUND_COLOR;
+                public CssMetaData<TextExt, Paint> getCssMetaData() {
+                    return StyleableProperties.BACKGROUND_FILL;
                 }
             };
         }
-        return backgroundColor;
+        return backgroundFill;
     }
 
     private static class StyleableProperties {
 
-        private static final CssMetaData<TextExt, Paint[]> BACKGROUND_COLOR = new CssMetaData<TextExt, Paint[]>(
-                "-fx-background-color",
-                PaintConverter.SequenceConverter.getInstance(),
-                new Paint[]{Color.TRANSPARENT}) {
+        private static final CssMetaData<TextExt, Paint> BACKGROUND_FILL = new CssMetaData<TextExt, Paint>(
+                "-fx-background-fill",
+                StyleConverter.getPaintConverter(),
+                Color.TRANSPARENT) {
             @Override
             public boolean isSettable(TextExt node) {
-                return node.backgroundColor == null || !node.backgroundColor.isBound();
+                return node.backgroundFill == null || !node.backgroundFill.isBound();
             }
 
             @Override
-            public StyleableProperty<Paint[]> getStyleableProperty(TextExt node) {
-                return (StyleableProperty<Paint[]>) node.backgroundColorProperty();
+            public StyleableProperty<Paint> getStyleableProperty(TextExt node) {
+                return (StyleableProperty<Paint>) node.backgroundFillProperty();
             }
         };
     }


### PR DESCRIPTION
Just as you suggested the implementation is based on the same principles as the selection fill.
On top of that I had to extend Text to support CSS based colors.

I should mention that I have only implemented -fx-background-color and not anything else from -fx-background. JavaFX under the hood is so damn weird that it would be rather ugly to support the actual Background property. Using just the color property makes the code simple and shouldn't have a huge impact like having an actual Image in every Text instance.

One thing I would like to improve is the background node instantiation. Right now every Text instance has a matching background Path. Maybe it is possible to create only Path instances when there actually is a background color set.

Well I'm actually quite happy with the result. It'S not perfect yet but it works great. The missing background color feature was a real show stopper for me. I'm glad that I was able to fix that. (taught me a lot about JavaFX)