### PR TITLE
Allow two or more StyledTextAreas (View) to share the same StyledDocument

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
@@ -1,0 +1,51 @@
+package org.fxmisc.richtext.demo;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.fxmisc.richtext.AreaFactory;
+import org.fxmisc.richtext.InlineCssTextArea;
+import org.fxmisc.richtext.StyledTextArea;
+
+public class CloneDemo extends Application {
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        String text = "Edit this area and watch the below area update itself.";
+        InlineCssTextArea area = AreaFactory.inlineCssTextArea(text);
+        StyledTextArea<String, String> clone = area.createClone();
+
+        printAreaCarePosition("area", area);
+        printAreaCarePosition("clone", clone);
+
+        area.positionCaret(area.getLength());
+        printAreaCarePosition("area", area);
+        printAreaCarePosition("clone", clone);
+
+        clone.replaceText(0, clone.getLength(), "");
+        printAreaCarePosition("area", area);
+        printAreaCarePosition("clone", clone);
+
+        area.replaceText(0, 0, text);
+        printAreaCarePosition("area", area);
+        printAreaCarePosition("clone", clone);
+
+        VBox vbox = new VBox(area, clone);
+        vbox.setSpacing(10);
+        StackPane pane = new StackPane(vbox);
+        Scene scene = new Scene(pane, 400, 400);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    void printAreaCarePosition(String areaName, StyledTextArea area) {
+        System.out.println("Caret position of " + areaName + ": " + String.valueOf(area.getCaretPosition()));
+    }
+
+}

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
@@ -2,7 +2,11 @@ package org.fxmisc.richtext.demo;
 
 import javafx.application.Application;
 import javafx.scene.Scene;
-import javafx.scene.layout.StackPane;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import org.fxmisc.richtext.AreaFactory;
@@ -19,27 +23,62 @@ public class CloneDemo extends Application {
     public void start(Stage primaryStage) {
         String text = "Edit this area and watch the below area update itself.";
         InlineCssTextArea area = AreaFactory.inlineCssTextArea(text);
-        StyledTextArea<String, String> clone = area.createClone();
-
-        printAreaCarePosition("area", area);
-        printAreaCarePosition("clone", clone);
-
-        area.positionCaret(area.getLength());
-        printAreaCarePosition("area", area);
-        printAreaCarePosition("clone", clone);
-
-        clone.replaceText(0, clone.getLength(), "");
-        printAreaCarePosition("area", area);
-        printAreaCarePosition("clone", clone);
-
-        area.replaceText(0, 0, text);
-        printAreaCarePosition("area", area);
-        printAreaCarePosition("clone", clone);
+        StyledTextArea<String, String> clone = AreaFactory.cloneInlineCssTextArea(area);
 
         VBox vbox = new VBox(area, clone);
         vbox.setSpacing(10);
-        StackPane pane = new StackPane(vbox);
-        Scene scene = new Scene(pane, 400, 400);
+
+        // set up labels displaying caret position
+        String caret = "Caret: ";
+        Label areaCaret = new Label(caret);
+        area.caretPositionProperty().addListener((observable, oldValue, newValue) -> {
+            areaCaret.setText(caret + String.valueOf(newValue));
+        });
+        Label cloneCaret = new Label(caret);
+        clone.caretPositionProperty().addListener((observable, oldValue, newValue) -> {
+            cloneCaret.setText(caret + String.valueOf(newValue));
+        });
+
+        // set up label's displaying selection position
+        String selText = "Selected Text: ";
+        Label areaSelection = new Label(selText);
+        area.selectedTextProperty().addListener(((observable, oldValue, newValue) -> {
+            areaSelection.setText(selText + newValue);
+        }));
+        Label cloneSelection = new Label(selText);
+        clone.selectedTextProperty().addListener(((observable, oldValue, newValue) -> {
+            cloneSelection.setText(selText + newValue);
+        }));
+
+        // set up Label's distinguishing which labels belong to which area.
+        Label areaLabel = new Label("Original Area: ");
+        Label cloneLabel = new Label("Cloned Area: ");
+
+        // set up Buttons that programmatically change area but not clone
+        Button deleteLastThreeChars = new Button("Click to Delete the previous 3 chars.");
+        deleteLastThreeChars.setOnAction((ae) -> {
+            for (int i = 0; i <= 2; i++) {
+                area.deletePreviousChar();
+            }
+        });
+
+        // finish GUI
+        GridPane grid = new GridPane();
+        grid.add(areaLabel, 0, 0);
+        grid.add(areaCaret, 1, 0);
+        grid.add(areaSelection, 2, 0);
+        grid.add(cloneLabel, 0, 1);
+        grid.add(cloneCaret, 1, 1);
+        grid.add(cloneSelection, 2, 1);
+        grid.setHgap(10);
+        grid.setVgap(4);
+
+        BorderPane pane = new BorderPane();
+        pane.setCenter(vbox);
+        pane.setTop(grid);
+        pane.setBottom(deleteLastThreeChars);
+
+        Scene scene = new Scene(pane, 800, 500);
         primaryStage.setScene(scene);
         primaryStage.show();
     }

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
@@ -82,9 +82,4 @@ public class CloneDemo extends Application {
         primaryStage.setScene(scene);
         primaryStage.show();
     }
-
-    void printAreaCarePosition(String areaName, StyledTextArea area) {
-        System.out.println("Caret position of " + areaName + ": " + String.valueOf(area.getCaretPosition()));
-    }
-
 }

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
@@ -6,7 +6,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import org.fxmisc.richtext.AreaFactory;

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichText.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichText.java
@@ -35,7 +35,6 @@ import javafx.stage.Stage;
 
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.AreaFactory;
-import org.fxmisc.richtext.InlineStyleTextArea;
 import org.fxmisc.richtext.Paragraph;
 import org.fxmisc.richtext.StyleSpans;
 import org.fxmisc.richtext.StyledTextArea;
@@ -48,11 +47,11 @@ public class RichText extends Application {
     }
 
     private final StyledTextArea<TextStyle, ParStyle> area =
-            AreaFactory.inlineStyleTextArea(
+            AreaFactory.<TextStyle, ParStyle>styledTextArea(
                     TextStyle.EMPTY.updateFontSize(12).updateFontFamily("Serif").updateTextColor(Color.BLACK),
-                    TextStyle::toCss,
+                    ( text, style) -> text.setStyle(style.toCss()),
                     ParStyle.EMPTY,
-                    ParStyle::toCss);
+                    ( paragraph, style) -> paragraph.setStyle(style.toCss()));
     {
         area.setWrapText(true);
         area.setStyleCodecs(TextStyle.CODEC, ParStyle.CODEC);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
@@ -175,36 +175,6 @@ public class AreaFactory {
         return new VirtualizedScrollPane<>(cloneCodeArea(virtualizedScrollPaneWithArea.getContent()));
     }
 
-
-
-    // Refactor: Since InlineStyleTextArea was deprecated, remove this
-    /**
-     * Creates a text area that uses inline css derived from the style info to define
-     * style of text segments.
-     *
-     * @param <S> type of text style information.
-     * @param <PS> type of paragraph style information.
-     * @param initialStyle style to use for text ranges where no other
-     *     style is set via {@code setStyle(...)} methods.
-     * @param styleToCss function that converts an instance of {@code S}
-     *     to a CSS string.
-     */
-    public static <S, PS> StyledTextArea<S, PS> inlineStyleTextArea(
-            S initialStyle, Function<S, String> styleToCss, PS initialParagraphStyle, Function<PS, String> paragraphStyleToCss
-    ) {
-        return styledTextArea(
-                initialStyle,
-                (text, style) -> text.setStyle(styleToCss.apply(style)),
-                initialParagraphStyle,
-                (paragraph, style) -> paragraph.setStyle(paragraphStyleToCss.apply(style)));
-    }
-
-    public static <S, PS> VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedInlineStyleTextArea(
-            S initialStyle, Function<S, String> styleToCss, PS initialParagraphStyle, Function<PS, String> paragraphStyleToCss
-    ) {
-        return new VirtualizedScrollPane<>(inlineStyleTextArea(initialStyle, styleToCss, initialParagraphStyle, paragraphStyleToCss));
-    }
-
     /* ********************************************************************** *
      *                                                                        *
      * InlineCssTextArea                                                      *

--- a/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
@@ -13,27 +13,25 @@ import java.util.function.Function;
  *
  */
 public class AreaFactory {
-    public static <S, PS> StyledTextArea<S, PS> styledTextArea(
-            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
-            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle, boolean preserveStyle
-    ) {
-        return new StyledTextArea<S, PS>(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, preserveStyle);
-    }
 
+    /* ********************************************************************** *
+     *                                                                        *
+     * StyledTextArea                                                         *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // StyledTextArea 1
     public static <S, PS> StyledTextArea<S, PS> styledTextArea(
             S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle
     ) {
-        return new StyledTextArea<S, PS>(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, true);
+        return new StyledTextArea<S, PS>(
+                initialStyle, applyStyle,
+                initialParagraphStyle, applyParagraphStyle,
+                true);
     }
 
-    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedStyledTextArea(
-            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
-            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle, boolean preserveStyle
-    ) {
-        return new VirtualizedScrollPane<>(styledTextArea(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, preserveStyle));
-    }
-
+    // Embeds StyledTextArea 1
     public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedStyledTextArea(
             S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle
@@ -41,38 +39,145 @@ public class AreaFactory {
         return new VirtualizedScrollPane<>(styledTextArea(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle));
     }
 
+    // StyledTextArea 2
+    public static <S, PS> StyledTextArea<S, PS> styledTextArea(
+            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+            boolean preserveStyle
+    ) {
+        return new StyledTextArea<S, PS>(
+                initialStyle, applyStyle,
+                initialParagraphStyle, applyParagraphStyle,
+                preserveStyle);
+    }
+
+    // Embeds StyledTextArea 2
+    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedStyledTextArea(
+            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle, boolean preserveStyle
+    ) {
+        return new VirtualizedScrollPane<>(styledTextArea(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, preserveStyle));
+    }
+
+    // StyledTextArea 3 (Clone of area)
+    public static <S, PS> StyledTextArea<S, PS> cloneStyleTextArea(StyledTextArea<S, PS> area) {
+        return new StyledTextArea<S, PS>(area.getInitialStyle(), area.getApplyStyle(),
+                area.getInitialParagraphStyle(), area.getApplyParagraphStyle(),
+                area.getCloneDocument(), area.isPreserveStyle());
+    }
+
+    // Embeds StyledTextArea 3
+    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedClonedStyledTextArea(StyledTextArea<S, PS> area) {
+        return new VirtualizedScrollPane<>(cloneStyleTextArea(area));
+    }
+
+    // Embeds StyledTextArea 3 using an area that is itself embedded in a VirtualizedScrollPane
+    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedClonedStyledTextArea(
+            VirtualizedScrollPane<StyledTextArea<S, PS>> virtualizedScrollPaneWithArea
+    ) {
+        return embeddedClonedStyledTextArea(virtualizedScrollPaneWithArea.getContent());
+    }
+
+    // refactor: Remove this as EditableStyledDocument is not public so nothing outside of RichTextFX can use it
+    public static <S, PS> StyledTextArea<S, PS> styledTextArea(
+            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+            EditableStyledDocument<S, PS> document, boolean preserveStyle
+    ) {
+        return new StyledTextArea<S, PS>(
+                initialStyle, applyStyle,
+                initialParagraphStyle, applyParagraphStyle,
+                document, preserveStyle
+        );
+    }
+
+    /* ********************************************************************** *
+     *                                                                        *
+     * StyleClassedTextArea                                                   *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // StyleClassedTextArea 1
     public static StyleClassedTextArea styleClassedTextArea(boolean preserveStyle) {
         return new StyleClassedTextArea(preserveStyle);
     }
 
-    public static StyleClassedTextArea styleClassedTextArea() {
-        return styleClassedTextArea(true);
-    }
-
+    // Embeds StyleClassedTextArea  1
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea(boolean preserveStyle) {
         return new VirtualizedScrollPane<>(styleClassedTextArea(preserveStyle));
     }
 
+    // StyleClassedTextArea  2
+    public static StyleClassedTextArea styleClassedTextArea() {
+        return styleClassedTextArea(true);
+    }
+
+    // Embeds StyleClassedTextArea  2
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea() {
         return new VirtualizedScrollPane<>(styleClassedTextArea());
     }
 
+    // Clones StyleClassedTextArea
+    public static StyleClassedTextArea cloneStyleClassedTextArea(StyleClassedTextArea area) {
+        return new StyleClassedTextArea(area.getCloneDocument(), area.isPreserveStyle());
+    }
+
+    // Embeds StyleClassedTextArea
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(StyleClassedTextArea area) {
+        return new VirtualizedScrollPane<>(cloneStyleClassedTextArea(area));
+    }
+
+    // Embeds a cloned StyleClassedTextArea from an embedded StyleClassedTextArea
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(
+            VirtualizedScrollPane<StyleClassedTextArea> virtualizedScrollPaneWithArea
+    ) {
+        return embeddedClonedStyleClassedTextArea(virtualizedScrollPaneWithArea.getContent());
+    }
+
+    /* ********************************************************************** *
+     *                                                                        *
+     * CodeArea                                                               *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // CodeArea 1
     public static CodeArea codeArea() {
         return new CodeArea();
     }
 
-    public static CodeArea codeArea(String text) {
-        return new CodeArea(text);
-    }
-
+    // Embeds CodeArea 1
     public static VirtualizedScrollPane<CodeArea> embeddedCodeArea() {
         return new VirtualizedScrollPane<>(codeArea());
     }
 
+    // CodeArea 2
+    public static CodeArea codeArea(String text) {
+        return new CodeArea(text);
+    }
+
+    // Embeds CodeArea 2
     public static VirtualizedScrollPane<CodeArea> embeddedCodeArea(String text) {
         return new VirtualizedScrollPane<>(codeArea(text));
     }
 
+    // Clones CodeArea
+    public static CodeArea cloneCodeArea(CodeArea area) {
+        return new CodeArea(area.getCloneDocument());
+    }
+
+    // Embeds a cloned CodeArea
+    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(CodeArea area) {
+        return new VirtualizedScrollPane<>(cloneCodeArea(area));
+    }
+
+    // Embeds a cloned CodeArea from an embedded CodeArea
+    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(VirtualizedScrollPane<CodeArea> virtualizedScrollPaneWithArea) {
+        return new VirtualizedScrollPane<>(cloneCodeArea(virtualizedScrollPaneWithArea.getContent()));
+    }
+
+
+
+    // Refactor: Since InlineStyleTextArea was deprecated, remove this
     /**
      * Creates a text area that uses inline css derived from the style info to define
      * style of text segments.
@@ -100,19 +205,43 @@ public class AreaFactory {
         return new VirtualizedScrollPane<>(inlineStyleTextArea(initialStyle, styleToCss, initialParagraphStyle, paragraphStyleToCss));
     }
 
+    /* ********************************************************************** *
+     *                                                                        *
+     * InlineCssTextArea                                                      *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // InlineCssTextArea 1
     public static InlineCssTextArea inlineCssTextArea() {
         return new InlineCssTextArea();
     }
 
-    public static InlineCssTextArea inlineCssTextArea(String text) {
-        return new InlineCssTextArea(text);
-    }
-
+    // Embeds InlineCssTextArea 1
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea() {
         return new VirtualizedScrollPane<>(inlineCssTextArea());
     }
 
+    // InlineCssTextArea 2
+    public static InlineCssTextArea inlineCssTextArea(String text) {
+        return new InlineCssTextArea(text);
+    }
+
+    // Embeds InlineCssTextArea 2
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea(String text) {
         return new VirtualizedScrollPane<>(inlineCssTextArea(text));
+    }
+
+    public static InlineCssTextArea cloneInlineCssTextArea(InlineCssTextArea area) {
+        return new InlineCssTextArea(area.getCloneDocument());
+    }
+
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(InlineCssTextArea area) {
+        return new VirtualizedScrollPane<>(cloneInlineCssTextArea(area));
+    }
+
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(
+            VirtualizedScrollPane<InlineCssTextArea> virtualizedScrollPaneWithArea
+    ) {
+        return new VirtualizedScrollPane<>(cloneInlineCssTextArea(virtualizedScrollPaneWithArea.getContent()));
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
@@ -1,6 +1,8 @@
 package org.fxmisc.richtext;
 
 
+import java.util.Collection;
+
 /**
  * A convenience subclass of {@link StyleClassedTextArea}
  * with fixed-width font and an undo manager that observes
@@ -16,6 +18,10 @@ public class CodeArea extends StyleClassedTextArea {
 
         // don't apply preceding style to typed text
         setUseInitialStyleForInsertion(true);
+    }
+
+    public CodeArea(EditableStyledDocument<Collection<String>, Collection<String>> document) {
+        super(document, false);
     }
 
     public CodeArea() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -16,6 +16,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import javafx.scene.control.IndexRange;
 import org.fxmisc.richtext.ReadOnlyStyledDocument.ParagraphsPolicy;
 import org.reactfx.EventSource;
 import org.reactfx.EventStream;
@@ -28,10 +29,14 @@ import org.reactfx.value.Var;
 
 /**
  * Content model for {@link StyledTextArea}. Implements edit operations
- * on styled text, but not worrying about additional aspects such as
- * caret or selection.
+ * on styled text and tracks caret and selection.
  */
 final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, ObservableList<Paragraph<S, PS>>> {
+
+    /**
+     * Index range [0, 0).
+     */
+    public static final IndexRange EMPTY_RANGE = new IndexRange(0, 0);
 
     /* ********************************************************************** *
      *                                                                        *
@@ -42,6 +47,29 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
      * response to user input and/or API actions.                             *
      *                                                                        *
      * ********************************************************************** */
+
+    // caret position
+    private final Var<Integer> caretPosition = Var.newSimpleVar(0);
+    Var<Integer> caretPositionProperty() { return caretPosition; }
+    int getCaretPosition() { return caretPosition.getValue(); }
+    void setCaretPosition(int position) { caretPosition.setValue(position); }
+
+    // internal selection
+    private final Var<IndexRange> selection = Var.newSimpleVar(EMPTY_RANGE);
+    Var<IndexRange> selectionProperty() { return selection; }
+    IndexRange getSelection() { return selection.getValue(); }
+    void setSelection(IndexRange range) { selection.setValue(range); }
+
+    private Position selectionStart2D = position(0, 0);
+    Position getSelectionStart2D() { return selectionStart2D; }
+
+    private Position selectionEnd2D = position(0, 0);
+    Position getSelectionEnd2D() { return selectionEnd2D; }
+
+    private final Val<String> selectedText = Val.create(
+                () -> getText(selection.getValue()),
+                selection, paragraphs);
+    Val<String> selectedTextProperty() { return selectedText; }
 
     /**
      * Content of this {@code StyledDocument}.
@@ -165,8 +193,42 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
         super(FXCollections.observableArrayList(new Paragraph<>(initialParagraphStyle, "", initialStyle)));
         this.initialStyle = initialStyle;
         this.initialParagraphStyle = initialParagraphStyle;
+        selection.addListener(obs -> {
+            IndexRange sel = selection.getValue();
+            selectionStart2D = offsetToPosition(sel.getStart(), Forward);
+            selectionEnd2D = sel.getLength() == 0
+                    ? selectionStart2D
+                    : selectionStart2D.offsetBy(sel.getLength(), Backward);
+        });
     }
 
+    /* ********************************************************************** *
+     *                                                                        *
+     * Queries                                                                *
+     *                                                                        *
+     * Queries are parameterized observables.                                 *
+     *                                                                        *
+     * ********************************************************************** */
+
+    /**
+     * Returns the selection range in the given paragraph.
+     */
+    IndexRange getParagraphSelection(int paragraph) {
+        int startPar = selectionStart2D.getMajor();
+        int endPar = selectionEnd2D.getMajor();
+
+        if(paragraph < startPar || paragraph > endPar) {
+            return EMPTY_RANGE;
+        }
+
+        int start = paragraph == startPar ? selectionStart2D.getMinor() : 0;
+        int end = paragraph == endPar ? selectionEnd2D.getMinor() : paragraphs.get(paragraph).length();
+
+        // force selectionProperty() to be valid
+        getSelection();
+
+        return new IndexRange(start, end);
+    }
 
     /* ********************************************************************** *
      *                                                                        *

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -22,6 +22,8 @@ import org.reactfx.EventSource;
 import org.reactfx.EventStream;
 import org.reactfx.EventStreams;
 import org.reactfx.Guard;
+import org.reactfx.collection.LiveList;
+import org.reactfx.collection.SuspendableList;
 import org.reactfx.util.Lists;
 import org.reactfx.value.SuspendableVar;
 import org.reactfx.value.Val;
@@ -66,9 +68,12 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
     private Position selectionEnd2D = position(0, 0);
     Position getSelectionEnd2D() { return selectionEnd2D; }
 
+    private final SuspendableList<Paragraph<S, PS>> suspendablePars = LiveList.suspendable(paragraphs);
+    SuspendableList<Paragraph<S, PS>> getSuspendablePars() { return suspendablePars; }
+
     private final Val<String> selectedText = Val.create(
                 () -> getText(selection.getValue()),
-                selection, paragraphs);
+                selection, suspendablePars);
     Val<String> selectedTextProperty() { return selectedText; }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
@@ -8,7 +8,17 @@ public class InlineCssTextArea extends StyledTextArea<String, String> {
     public InlineCssTextArea() {
         super(
                 "", (text, style) -> text.setStyle(style),
-                "", (paragraph, style) -> paragraph.setStyle(style)
+                "", (paragraph, style) -> paragraph.setStyle(style),
+                new EditableStyledDocument<String, String>("", "")
+        );
+    }
+
+    public InlineCssTextArea(EditableStyledDocument<String, String> document) {
+        super(
+                "", (text, style) -> text.setStyle(style),
+                "", (paragraph, style) -> paragraph.setStyle(style),
+                document,
+                true
         );
     }
 
@@ -30,5 +40,4 @@ public class InlineCssTextArea extends StyledTextArea<String, String> {
         // position the caret at the beginning
         selectRange(0, 0);
     }
-
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineStyleTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineStyleTextArea.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
  * style of text segments.
  *
  * @param <S> type of style information.
- * @deprecated Use {@link AreaFactory#inlineStyleTextArea(Object, Function, Object, Function)} instead
+ * @deprecated
  */
 @Deprecated
 public class InlineStyleTextArea<S, PS> extends StyledTextArea<S, PS> {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
@@ -10,16 +10,22 @@ import java.util.List;
  */
 public class StyleClassedTextArea extends StyledTextArea<Collection<String>, Collection<String>> {
 
-    public StyleClassedTextArea(boolean preserveStyle) {
+    public StyleClassedTextArea(EditableStyledDocument<Collection<String>, Collection<String>> document, boolean preserveStyle) {
         super(Collections.<String>emptyList(),
                 (text, styleClasses) -> text.getStyleClass().addAll(styleClasses),
                 Collections.<String>emptyList(),
                 (paragraph, styleClasses) -> paragraph.getStyleClass().addAll(styleClasses),
-                preserveStyle);
+                document, preserveStyle
+        );
 
         setStyleCodecs(
                 SuperCodec.upCast(SuperCodec.collectionListCodec(Codec.STRING_CODEC)),
-                SuperCodec.upCast(SuperCodec.collectionListCodec(Codec.STRING_CODEC)));
+                SuperCodec.upCast(SuperCodec.collectionListCodec(Codec.STRING_CODEC))
+        );
+    }
+    public StyleClassedTextArea(boolean preserveStyle) {
+        this(
+            new EditableStyledDocument<Collection<String>, Collection<String>>(Collections.<String>emptyList(), Collections.<String>emptyList()), true);
     }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -412,6 +412,8 @@ public class StyledTextArea<S, PS> extends Region
      *                                                                        *
      * ********************************************************************** */
 
+    private final StyledTextAreaBehavior behavior;
+
     private Subscription subscriptions = () -> {};
 
     private final Binding<Boolean> caretVisible;
@@ -624,7 +626,7 @@ public class StyledTextArea<S, PS> extends Region
                         : EventStreams.never())
                 .subscribe(evt -> Event.fireEvent(this, evt));
 
-        new StyledTextAreaBehavior(this);
+        behavior = new StyledTextAreaBehavior(this);
         getChildren().add(virtualFlow);
     }
 
@@ -1067,6 +1069,7 @@ public class StyledTextArea<S, PS> extends Region
 
     public void dispose() {
         subscriptions.unsubscribe();
+        behavior.dispose();
         virtualFlow.dispose();
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -388,7 +388,6 @@ public class StyledTextArea<S, PS> extends Region
     public Val<Double> totalHeightEstimateProperty() { return virtualFlow.totalHeightEstimateProperty(); }
     public double getTotalHeightEstimate() { return virtualFlow.totalHeightEstimateProperty().getValue(); }
 
-
     /* ********************************************************************** *
      *                                                                        *
      * Event streams                                                          *
@@ -404,7 +403,6 @@ public class StyledTextArea<S, PS> extends Region
     private final SuspendableEventStream<RichTextChange<S, PS>> richTextChanges;
     @Override
     public final EventStream<RichTextChange<S, PS>> richChanges() { return richTextChanges; }
-
 
     /* ********************************************************************** *
      *                                                                        *
@@ -432,26 +430,41 @@ public class StyledTextArea<S, PS> extends Region
      * content model
      */
     private final EditableStyledDocument<S, PS> content;
+    protected final EditableStyledDocument<S, PS> getCloneDocument() {
+        return content;
+    }
 
     /**
      * Style used by default when no other style is provided.
      */
     private final S initialStyle;
+    protected final S getInitialStyle() {
+        return initialStyle;
+    }
 
     /**
      * Style used by default when no other style is provided.
      */
     private final PS initialParagraphStyle;
+    protected final PS getInitialParagraphStyle() {
+        return initialParagraphStyle;
+    }
 
     /**
      * Style applicator used by the default skin.
      */
     private final BiConsumer<? super TextExt, S> applyStyle;
+    protected final BiConsumer<? super TextExt, S> getApplyStyle() {
+        return applyStyle;
+    }
 
     /**
      * Style applicator used by the default skin.
      */
     private final BiConsumer<TextFlow, PS> applyParagraphStyle;
+    protected final BiConsumer<TextFlow, PS> getApplyParagraphStyle() {
+        return applyParagraphStyle;
+    }
 
     /**
      * Indicates whether style should be preserved on undo/redo,
@@ -459,6 +472,9 @@ public class StyledTextArea<S, PS> extends Region
      * TODO: Currently, only undo/redo respect this flag.
      */
     private final boolean preserveStyle;
+    protected final boolean isPreserveStyle() {
+        return preserveStyle;
+    }
 
     private final Suspendable omniSuspendable;
 
@@ -483,27 +499,37 @@ public class StyledTextArea<S, PS> extends Region
      * a style, applies the style to the paragraph node. This function is
      * used by the default skin to apply style to paragraph nodes.
      */
-    public StyledTextArea(S initialStyle, BiConsumer<? super TextExt, S> applyStyle, PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle) {
+    public StyledTextArea(S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+                          PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle
+    ) {
         this(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, true);
+    }
+
+    public <C> StyledTextArea(S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+                              PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              boolean preserveStyle
+    ) {
+        this(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle,
+                new EditableStyledDocument<S, PS>(initialStyle, initialParagraphStyle), preserveStyle);
+    }
+
+    /**
+     * The same as {@link #StyledTextArea(Object, BiConsumer, Object, BiConsumer)} except that
+     * this constructor can be used to create another {@code StyledTextArea} object that
+     * shares the same {@link EditableStyledDocument}.
+     */
+    public StyledTextArea(S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+                          PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                          EditableStyledDocument<S, PS> document
+    ) {
+        this(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, document, true);
+
     }
 
     public StyledTextArea(S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
                           PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                          boolean preserveStyle) {
-        this(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle,
-            new EditableStyledDocument<S, PS>(initialStyle, initialParagraphStyle),
-                preserveStyle);
-    }
-
-    public StyledTextArea<S, PS> createClone() {
-        return new StyledTextArea<>(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle,
-                content, preserveStyle);
-    }
-
-    public <C> StyledTextArea(S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
-            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-            EditableStyledDocument<S, PS> document,
-            boolean preserveStyle) {
+                          EditableStyledDocument<S, PS> document, boolean preserveStyle
+    ) {
         this.initialStyle = initialStyle;
         this.initialParagraphStyle = initialParagraphStyle;
         this.applyStyle = applyStyle;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -418,7 +418,6 @@ public class StyledTextArea<S, PS> extends Region
 
     private final Binding<Boolean> caretVisible;
 
-    // TODO: this is initialized but never used. Should it be removed?
     private final Val<UnaryOperator<Point2D>> _popupAnchorAdjustment;
 
     private final VirtualFlow<Paragraph<S, PS>, Cell<Paragraph<S, PS>, ParagraphBox<S, PS>>> virtualFlow;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -423,8 +423,6 @@ public class StyledTextArea<S, PS> extends Region
 
     private final VirtualFlow<Paragraph<S, PS>, Cell<Paragraph<S, PS>, ParagraphBox<S, PS>>> virtualFlow;
 
-    private final VirtualizedScrollPane<VirtualFlow> virtualizedScrollPane;
-
     // used for two-level navigation, where on the higher level are
     // paragraphs and on the lower level are lines within a paragraph
     private final TwoLevelNavigator navigator;
@@ -576,8 +574,7 @@ public class StyledTextArea<S, PS> extends Region
                     return cell.beforeReset(() -> nonEmptyCells.remove(cell.getNode()))
                             .afterUpdateItem(p -> nonEmptyCells.add(cell.getNode()));
                 });
-        virtualizedScrollPane = new VirtualizedScrollPane<>(virtualFlow);
-        getChildren().add(virtualizedScrollPane);
+        getChildren().add(virtualFlow);
 
         // initialize navigator
         IntSupplier cellCount = () -> getParagraphs().size();
@@ -627,7 +624,6 @@ public class StyledTextArea<S, PS> extends Region
                 .subscribe(evt -> Event.fireEvent(this, evt));
 
         behavior = new StyledTextAreaBehavior(this);
-        getChildren().add(virtualFlow);
     }
 
 
@@ -1081,7 +1077,7 @@ public class StyledTextArea<S, PS> extends Region
 
     @Override
     protected void layoutChildren() {
-        virtualizedScrollPane.resize(getWidth(), getHeight());
+        virtualFlow.resize(getWidth(), getHeight());
         if(followCaretRequested) {
             followCaretRequested = false;
             followCaret();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -536,7 +536,7 @@ public class StyledTextArea<S, PS> extends Region
         this.applyParagraphStyle = applyParagraphStyle;
         this.preserveStyle = preserveStyle;
         content = document;
-        paragraphs = LiveList.suspendable(content.getParagraphs());
+        paragraphs = content.getSuspendablePars();
 
         text = Val.suspendable(content.textProperty());
         length = Val.suspendable(content.lengthProperty());


### PR DESCRIPTION
- Changed StyledTextArea's base constructor to take an EditableStyledDocument parameter. Then added an intermediary constructor (that returns the same object as previous base constructor) which creates an EditableStyledDocument before calling the new base constructor
- Moved caret and selection-related variables from StyledTextArea to EditableStyledDocument.
- Updated EditableStyledDocument's javadoc: now tracks caret and selection.
- Moved StyledTextArea's `getParagraphSelection` code implementation to EditableStyledDocument
- Added a demo, CloneDemo, that illustrates two StyledTextArea objects that share the same document.