### PR TITLE
Remove TODO reminder and last remnants of VirtualizedScrollPane

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -429,7 +429,6 @@ public class StyledTextArea<S, PS> extends Region
 
     private final Binding<Boolean> caretVisible;
 
-    // TODO: this is initialized but never used. Should it be removed?
     private final Val<UnaryOperator<Point2D>> _popupAnchorAdjustment;
 
     private final VirtualFlow<Paragraph<S, PS>, Cell<Paragraph<S, PS>, ParagraphBox<S, PS>>> virtualFlow;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -433,8 +433,6 @@ public class StyledTextArea<S, PS> extends Region
 
     private final VirtualFlow<Paragraph<S, PS>, Cell<Paragraph<S, PS>, ParagraphBox<S, PS>>> virtualFlow;
 
-    private final VirtualizedScrollPane<VirtualFlow> virtualizedScrollPane;
-
     // used for two-level navigation, where on the higher level are
     // paragraphs and on the lower level are lines within a paragraph
     private final TwoLevelNavigator navigator;
@@ -584,8 +582,7 @@ public class StyledTextArea<S, PS> extends Region
                     return cell.beforeReset(() -> nonEmptyCells.remove(cell.getNode()))
                             .afterUpdateItem(p -> nonEmptyCells.add(cell.getNode()));
                 });
-        virtualizedScrollPane = new VirtualizedScrollPane<>(virtualFlow);
-        getChildren().add(virtualizedScrollPane);
+        getChildren().add(virtualFlow);
 
         // initialize navigator
         IntSupplier cellCount = () -> getParagraphs().size();
@@ -632,7 +629,6 @@ public class StyledTextArea<S, PS> extends Region
                 .subscribe(evt -> Event.fireEvent(this, evt));
 
         new StyledTextAreaBehavior(this);
-        getChildren().add(virtualFlow);
     }
 
 
@@ -1087,7 +1083,7 @@ public class StyledTextArea<S, PS> extends Region
 
     @Override
     protected void layoutChildren() {
-        virtualizedScrollPane.resize(getWidth(), getHeight());
+        virtualFlow.resize(getWidth(), getHeight());
         if(followCaretRequested) {
             followCaretRequested = false;
             followCaret();


### PR DESCRIPTION
I'm removing the TODO reminder as its irrelevant.

It looks like we missed the VIrtualizedScrollPane component that shouldn't be apart of this anymore. So, I'm removing that before anything else gets done.