### PR TITLE
Allow two or more StyledTextAreas (View) to share the same StyledDocument (Model)

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
@@ -1,0 +1,87 @@
+package org.fxmisc.richtext.demo;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.fxmisc.richtext.AreaFactory;
+import org.fxmisc.richtext.InlineCssTextArea;
+
+public class CloneDemo extends Application {
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        String selectedText = "selection";
+        String text = "Edit the top area (original)\nand watch the (clone) bottom area's displayed text change and its " +
+                "selected text [" + selectedText + "] update itself accordingly.";
+        InlineCssTextArea area = AreaFactory.inlineCssTextArea(text);
+        InlineCssTextArea clone = AreaFactory.cloneInlineCssTextArea(area);
+
+        VBox vbox = new VBox(area, clone);
+        vbox.setSpacing(10);
+
+        // set up labels displaying caret position
+        String caret = "Caret: ";
+        Label areaCaret = new Label(caret);
+        area.caretPositionProperty().addListener((observable, oldValue, newValue) -> areaCaret.setText(caret + String.valueOf(newValue)));
+        Label cloneCaret = new Label(caret);
+        clone.caretPositionProperty().addListener((observable, oldValue, newValue) -> cloneCaret.setText(caret + String.valueOf(newValue)));
+
+        // set up label's displaying selection position
+        String selection = "Selected Text: ";
+        Label areaSelection = new Label(selection);
+        area.selectedTextProperty().addListener(((observable, oldValue, newValue) -> areaSelection.setText(selection + newValue)));
+        Label cloneSelection = new Label(selection);
+        clone.selectedTextProperty().addListener(((observable, oldValue, newValue) -> cloneSelection.setText(selection + newValue)));
+
+        // now that listeners are set up update the selection for clone
+        int selectionStart = text.indexOf(selectedText);
+        int selectionEnd   = selectionStart +  selectedText.length();
+        clone.selectRange(selectionStart, selectionEnd);
+
+        // set up Label's distinguishing which labels belong to which area.
+        Label areaLabel = new Label("Original Area: ");
+        Label cloneLabel = new Label("Cloned Area: ");
+
+        // set up Buttons that programmatically change area but not clone
+        Button deleteLastThreeChars = new Button("Click to Delete the previous 3 chars.");
+        deleteLastThreeChars.setOnAction((ae) -> {
+            for (int i = 0; i <= 2; i++) {
+                area.deletePreviousChar();
+            }
+        });
+
+        // finish GUI
+        GridPane grid = new GridPane();
+        // add area content to first row
+        grid.add(areaLabel, 0, 0);
+        grid.add(areaCaret, 1, 0);
+        grid.add(areaSelection, 2, 0);
+
+        // add clone content to second row
+        grid.add(cloneLabel, 0, 1);
+        grid.add(cloneCaret, 1, 1);
+        grid.add(cloneSelection, 2, 1);
+
+        grid.setHgap(10);
+        grid.setVgap(4);
+
+        BorderPane pane = new BorderPane();
+        pane.setCenter(vbox);
+        pane.setTop(grid);
+        pane.setBottom(deleteLastThreeChars);
+
+        Scene scene = new Scene(pane, 800, 500);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+}

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichText.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichText.java
@@ -35,7 +35,6 @@ import javafx.stage.Stage;
 
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.AreaFactory;
-import org.fxmisc.richtext.InlineStyleTextArea;
 import org.fxmisc.richtext.Paragraph;
 import org.fxmisc.richtext.StyleSpans;
 import org.fxmisc.richtext.StyledTextArea;
@@ -48,11 +47,11 @@ public class RichText extends Application {
     }
 
     private final StyledTextArea<TextStyle, ParStyle> area =
-            AreaFactory.inlineStyleTextArea(
+            AreaFactory.<TextStyle, ParStyle>styledTextArea(
                     TextStyle.EMPTY.updateFontSize(12).updateFontFamily("Serif").updateTextColor(Color.BLACK),
-                    TextStyle::toCss,
+                    ( text, style) -> text.setStyle(style.toCss()),
                     ParStyle.EMPTY,
-                    ParStyle::toCss);
+                    ( paragraph, style) -> paragraph.setStyle(style.toCss()));
     {
         area.setWrapText(true);
         area.setStyleCodecs(TextStyle.CODEC, ParStyle.CODEC);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
@@ -13,27 +13,25 @@ import java.util.function.Function;
  *
  */
 public class AreaFactory {
-    public static <S, PS> StyledTextArea<S, PS> styledTextArea(
-            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
-            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle, boolean preserveStyle
-    ) {
-        return new StyledTextArea<S, PS>(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, preserveStyle);
-    }
 
+    /* ********************************************************************** *
+     *                                                                        *
+     * StyledTextArea                                                         *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // StyledTextArea 1
     public static <S, PS> StyledTextArea<S, PS> styledTextArea(
             S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle
     ) {
-        return new StyledTextArea<S, PS>(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, true);
+        return new StyledTextArea<S, PS>(
+                initialStyle, applyStyle,
+                initialParagraphStyle, applyParagraphStyle,
+                true);
     }
 
-    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedStyledTextArea(
-            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
-            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle, boolean preserveStyle
-    ) {
-        return new VirtualizedScrollPane<>(styledTextArea(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, preserveStyle));
-    }
-
+    // Embeds StyledTextArea 1
     public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedStyledTextArea(
             S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle
@@ -41,78 +39,169 @@ public class AreaFactory {
         return new VirtualizedScrollPane<>(styledTextArea(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle));
     }
 
+    // StyledTextArea 2
+    public static <S, PS> StyledTextArea<S, PS> styledTextArea(
+            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+            boolean preserveStyle
+    ) {
+        return new StyledTextArea<S, PS>(
+                initialStyle, applyStyle,
+                initialParagraphStyle, applyParagraphStyle,
+                preserveStyle);
+    }
+
+    // Embeds StyledTextArea 2
+    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedStyledTextArea(
+            S initialStyle, BiConsumer<? super TextExt, S> applyStyle,
+            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle, boolean preserveStyle
+    ) {
+        return new VirtualizedScrollPane<>(styledTextArea(initialStyle, applyStyle, initialParagraphStyle, applyParagraphStyle, preserveStyle));
+    }
+
+    // Clones StyledTextArea
+    public static <S, PS> StyledTextArea<S, PS> cloneStyleTextArea(StyledTextArea<S, PS> area) {
+        return new StyledTextArea<S, PS>(area.getInitialStyle(), area.getApplyStyle(),
+                area.getInitialParagraphStyle(), area.getApplyParagraphStyle(),
+                area.getCloneDocument(), area.isPreserveStyle());
+    }
+
+    // Embeds cloned StyledTextArea
+    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedClonedStyledTextArea(StyledTextArea<S, PS> area) {
+        return new VirtualizedScrollPane<>(cloneStyleTextArea(area));
+    }
+
+    // Embeds a cloned StyledTextArea from an embedded StyledTextArea
+    public static <S, PS>VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedClonedStyledTextArea(
+            VirtualizedScrollPane<StyledTextArea<S, PS>> virtualizedScrollPaneWithArea
+    ) {
+        return embeddedClonedStyledTextArea(virtualizedScrollPaneWithArea.getContent());
+    }
+
+    /* ********************************************************************** *
+     *                                                                        *
+     * StyleClassedTextArea                                                   *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // StyleClassedTextArea 1
     public static StyleClassedTextArea styleClassedTextArea(boolean preserveStyle) {
         return new StyleClassedTextArea(preserveStyle);
     }
 
-    public static StyleClassedTextArea styleClassedTextArea() {
-        return styleClassedTextArea(true);
-    }
-
+    // Embeds StyleClassedTextArea  1
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea(boolean preserveStyle) {
         return new VirtualizedScrollPane<>(styleClassedTextArea(preserveStyle));
     }
 
+    // StyleClassedTextArea  2
+    public static StyleClassedTextArea styleClassedTextArea() {
+        return styleClassedTextArea(true);
+    }
+
+    // Embeds StyleClassedTextArea  2
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea() {
         return new VirtualizedScrollPane<>(styleClassedTextArea());
     }
 
+    // Clones StyleClassedTextArea
+    public static StyleClassedTextArea cloneStyleClassedTextArea(StyleClassedTextArea area) {
+        return new StyleClassedTextArea(area.getCloneDocument(), area.isPreserveStyle());
+    }
+
+    // Embeds cloned StyleClassedTextArea
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(StyleClassedTextArea area) {
+        return new VirtualizedScrollPane<>(cloneStyleClassedTextArea(area));
+    }
+
+    // Embeds a cloned StyleClassedTextArea from an embedded StyleClassedTextArea
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(
+            VirtualizedScrollPane<StyleClassedTextArea> virtualizedScrollPaneWithArea
+    ) {
+        return embeddedClonedStyleClassedTextArea(virtualizedScrollPaneWithArea.getContent());
+    }
+
+    /* ********************************************************************** *
+     *                                                                        *
+     * CodeArea                                                               *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // CodeArea 1
     public static CodeArea codeArea() {
         return new CodeArea();
     }
 
-    public static CodeArea codeArea(String text) {
-        return new CodeArea(text);
-    }
-
+    // Embeds CodeArea 1
     public static VirtualizedScrollPane<CodeArea> embeddedCodeArea() {
         return new VirtualizedScrollPane<>(codeArea());
     }
 
+    // CodeArea 2
+    public static CodeArea codeArea(String text) {
+        return new CodeArea(text);
+    }
+
+    // Embeds CodeArea 2
     public static VirtualizedScrollPane<CodeArea> embeddedCodeArea(String text) {
         return new VirtualizedScrollPane<>(codeArea(text));
     }
 
-    /**
-     * Creates a text area that uses inline css derived from the style info to define
-     * style of text segments.
-     *
-     * @param <S> type of text style information.
-     * @param <PS> type of paragraph style information.
-     * @param initialStyle style to use for text ranges where no other
-     *     style is set via {@code setStyle(...)} methods.
-     * @param styleToCss function that converts an instance of {@code S}
-     *     to a CSS string.
-     */
-    public static <S, PS> StyledTextArea<S, PS> inlineStyleTextArea(
-            S initialStyle, Function<S, String> styleToCss, PS initialParagraphStyle, Function<PS, String> paragraphStyleToCss
-    ) {
-        return styledTextArea(
-                initialStyle,
-                (text, style) -> text.setStyle(styleToCss.apply(style)),
-                initialParagraphStyle,
-                (paragraph, style) -> paragraph.setStyle(paragraphStyleToCss.apply(style)));
+    // Clones CodeArea
+    public static CodeArea cloneCodeArea(CodeArea area) {
+        return new CodeArea(area.getCloneDocument());
     }
 
-    public static <S, PS> VirtualizedScrollPane<StyledTextArea<S, PS>> embeddedInlineStyleTextArea(
-            S initialStyle, Function<S, String> styleToCss, PS initialParagraphStyle, Function<PS, String> paragraphStyleToCss
-    ) {
-        return new VirtualizedScrollPane<>(inlineStyleTextArea(initialStyle, styleToCss, initialParagraphStyle, paragraphStyleToCss));
+    // Embeds a cloned CodeArea
+    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(CodeArea area) {
+        return new VirtualizedScrollPane<>(cloneCodeArea(area));
     }
 
+    // Embeds a cloned CodeArea from an embedded CodeArea
+    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(VirtualizedScrollPane<CodeArea> virtualizedScrollPaneWithArea) {
+        return new VirtualizedScrollPane<>(cloneCodeArea(virtualizedScrollPaneWithArea.getContent()));
+    }
+
+    /* ********************************************************************** *
+     *                                                                        *
+     * InlineCssTextArea                                                      *
+     *                                                                        *
+     * ********************************************************************** */
+
+    // InlineCssTextArea 1
     public static InlineCssTextArea inlineCssTextArea() {
         return new InlineCssTextArea();
     }
 
-    public static InlineCssTextArea inlineCssTextArea(String text) {
-        return new InlineCssTextArea(text);
-    }
-
+    // Embeds InlineCssTextArea 1
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea() {
         return new VirtualizedScrollPane<>(inlineCssTextArea());
     }
 
+    // InlineCssTextArea 2
+    public static InlineCssTextArea inlineCssTextArea(String text) {
+        return new InlineCssTextArea(text);
+    }
+
+    // Embeds InlineCssTextArea 2
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea(String text) {
         return new VirtualizedScrollPane<>(inlineCssTextArea(text));
+    }
+
+    // Clones InlineCssTextArea
+    public static InlineCssTextArea cloneInlineCssTextArea(InlineCssTextArea area) {
+        return new InlineCssTextArea(area.getCloneDocument());
+    }
+
+    // Embeds a cloned InlineCssTextArea
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(InlineCssTextArea area) {
+        return new VirtualizedScrollPane<>(cloneInlineCssTextArea(area));
+    }
+
+    // Embeds a cloned InlineCssTextArea from an embedded InlineCssTextArea
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(
+            VirtualizedScrollPane<InlineCssTextArea> virtualizedScrollPaneWithArea
+    ) {
+        return new VirtualizedScrollPane<>(cloneInlineCssTextArea(virtualizedScrollPaneWithArea.getContent()));
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
@@ -1,6 +1,8 @@
 package org.fxmisc.richtext;
 
 
+import java.util.Collection;
+
 /**
  * A convenience subclass of {@link StyleClassedTextArea}
  * with fixed-width font and an undo manager that observes
@@ -16,6 +18,10 @@ public class CodeArea extends StyleClassedTextArea {
 
         // don't apply preceding style to typed text
         setUseInitialStyleForInsertion(true);
+    }
+
+    public CodeArea(EditableStyledDocument<Collection<String>, Collection<String>> document) {
+        super(document, false);
     }
 
     public CodeArea() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -21,6 +21,7 @@ import org.reactfx.EventSource;
 import org.reactfx.EventStream;
 import org.reactfx.EventStreams;
 import org.reactfx.Guard;
+import org.reactfx.Suspendable;
 import org.reactfx.SuspendableNo;
 import org.reactfx.util.Lists;
 import org.reactfx.value.SuspendableVar;
@@ -389,6 +390,24 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
      * Private and package private methods                                    *
      *                                                                        *
      * ********************************************************************** */
+
+    private final List<Suspendable> suspendables = new ArrayList<>(1);
+    void addSuspendable(Suspendable omniSuspendable) {suspendables.add(omniSuspendable);}
+    void removeSuspendable(Suspendable omnisuspendable) {suspendables.remove(omnisuspendable);}
+
+    private List<Guard> guards = null;
+    void suspendAll() {
+        guards = new ArrayList<>(suspendables.size());
+        for (Suspendable omni : suspendables) {
+            guards.add(omni.suspend());
+        }
+    }
+    void unsuspendAll() {
+        for (Guard g : guards) {
+            g.close();
+        }
+        guards = null;
+    }
 
     private void ensureValidParagraphIndex(int parIdx) {
         Lists.checkIndex(parIdx, paragraphs.size());

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -21,6 +21,7 @@ import org.reactfx.EventSource;
 import org.reactfx.EventStream;
 import org.reactfx.EventStreams;
 import org.reactfx.Guard;
+import org.reactfx.SuspendableNo;
 import org.reactfx.util.Lists;
 import org.reactfx.value.SuspendableVar;
 import org.reactfx.value.Val;
@@ -59,6 +60,10 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
     public Val<Integer> lengthProperty() { return length; }
     @Override
     public int length() { return length.getValue(); }
+
+    private final SuspendableNo beingUpdated = new SuspendableNo();
+    SuspendableNo beingUpdatedProperty() { return beingUpdated; }
+    public boolean isBeingUpdated() { return beingUpdated.get(); }
 
     /**
      * Unmodifiable observable list of styled paragraphs of this document.

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -387,18 +387,12 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
     void addSuspendable(Suspendable omniSuspendable) {suspendables.add(omniSuspendable);}
     void removeSuspendable(Suspendable omnisuspendable) {suspendables.remove(omnisuspendable);}
 
-    private List<Guard> guards = null;
-    void suspendAll() {
-        guards = new ArrayList<>(suspendables.size());
-        for (Suspendable omni : suspendables) {
-            guards.add(omni.suspend());
+    Guard suspendAll() {
+        Suspendable[] suspendablesArray = new Suspendable[suspendables.size()];
+        for (int i = 0; i < suspendables.size(); i++) {
+            suspendablesArray[i] = suspendables.get(i);
         }
-    }
-    void unsuspendAll() {
-        for (Guard g : guards) {
-            g.close();
-        }
-        guards = null;
+        return Suspendable.combine(suspendablesArray).suspend();
     }
 
     private void ensureValidParagraphIndex(int parIdx) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -61,6 +61,10 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
     @Override
     public int length() { return length.getValue(); }
 
+    /**
+     * Used by each StyledTextArea that is attached to this document
+     * to insure that published updates are consistent.
+     */
     private final SuspendableNo beingUpdated = new SuspendableNo();
     SuspendableNo beingUpdatedProperty() { return beingUpdated; }
     public boolean isBeingUpdated() { return beingUpdated.get(); }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -63,14 +63,6 @@ final class EditableStyledDocument<S, PS> extends StyledDocumentBase<S, PS, Obse
     public int length() { return length.getValue(); }
 
     /**
-     * Used by each StyledTextArea that is attached to this document
-     * to insure that published updates are consistent.
-     */
-    private final SuspendableNo beingUpdated = new SuspendableNo();
-    SuspendableNo beingUpdatedProperty() { return beingUpdated; }
-    public boolean isBeingUpdated() { return beingUpdated.get(); }
-
-    /**
      * Unmodifiable observable list of styled paragraphs of this document.
      */
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
@@ -6,9 +6,15 @@ package org.fxmisc.richtext;
 public class InlineCssTextArea extends StyledTextArea<String, String> {
 
     public InlineCssTextArea() {
+        this(new EditableStyledDocument<String, String>("", ""));
+    }
+
+    public InlineCssTextArea(EditableStyledDocument<String, String> document) {
         super(
                 "", (text, style) -> text.setStyle(style),
-                "", (paragraph, style) -> paragraph.setStyle(style)
+                "", (paragraph, style) -> paragraph.setStyle(style),
+                document,
+                true
         );
     }
 
@@ -30,5 +36,4 @@ public class InlineCssTextArea extends StyledTextArea<String, String> {
         // position the caret at the beginning
         selectRange(0, 0);
     }
-
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineStyleTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineStyleTextArea.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
  * style of text segments.
  *
  * @param <S> type of style information.
- * @deprecated Use {@link AreaFactory#inlineStyleTextArea(Object, Function, Object, Function)} instead
+ * @deprecated
  */
 @Deprecated
 public class InlineStyleTextArea<S, PS> extends StyledTextArea<S, PS> {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
@@ -10,16 +10,24 @@ import java.util.List;
  */
 public class StyleClassedTextArea extends StyledTextArea<Collection<String>, Collection<String>> {
 
-    public StyleClassedTextArea(boolean preserveStyle) {
+    public StyleClassedTextArea(EditableStyledDocument<Collection<String>, Collection<String>> document, boolean preserveStyle) {
         super(Collections.<String>emptyList(),
                 (text, styleClasses) -> text.getStyleClass().addAll(styleClasses),
                 Collections.<String>emptyList(),
                 (paragraph, styleClasses) -> paragraph.getStyleClass().addAll(styleClasses),
-                preserveStyle);
+                document, preserveStyle
+        );
 
         setStyleCodecs(
                 SuperCodec.upCast(SuperCodec.collectionListCodec(Codec.STRING_CODEC)),
-                SuperCodec.upCast(SuperCodec.collectionListCodec(Codec.STRING_CODEC)));
+                SuperCodec.upCast(SuperCodec.collectionListCodec(Codec.STRING_CODEC))
+        );
+    }
+    public StyleClassedTextArea(boolean preserveStyle) {
+        this(
+                new EditableStyledDocument<Collection<String>, Collection<String>>(
+                    Collections.<String>emptyList(), Collections.<String>emptyList()
+                ), preserveStyle);
     }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -380,8 +380,9 @@ public class StyledTextArea<S, PS> extends Region
     }
 
     // beingUpdated
-    public ObservableBooleanValue beingUpdatedProperty() { return content.beingUpdatedProperty(); }
-    public boolean isBeingUpdated() { return content.isBeingUpdated(); }
+    private final SuspendableNo beingUpdated = new SuspendableNo();
+    public ObservableBooleanValue beingUpdatedProperty() { return beingUpdated; }
+    public boolean isBeingUpdated() { return beingUpdated.get(); }
 
     // total width estimate
     /**
@@ -625,7 +626,7 @@ public class StyledTextArea<S, PS> extends Region
                 internalSelection, content.getParagraphs()).suspendable();
 
         Suspendable omniSuspendable = Suspendable.combine(
-                content.beingUpdatedProperty(), // must be first, to be the last one to release
+                beingUpdated, // must be first, to be the last one to release
                 text,
                 length,
                 caretPosition,
@@ -1378,6 +1379,6 @@ public class StyledTextArea<S, PS> extends Region
     }
 
     private Guard suspend(Suspendable... suspendables) {
-        return Suspendable.combine(content.beingUpdatedProperty(), Suspendable.combine(suspendables)).suspend();
+        return Suspendable.combine(beingUpdated, Suspendable.combine(suspendables)).suspend();
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -494,8 +494,6 @@ public class StyledTextArea<S, PS> extends Region
         return preserveStyle;
     }
 
-    private final Suspendable omniSuspendable;
-
 
     /* ********************************************************************** *
      *                                                                        *
@@ -626,7 +624,7 @@ public class StyledTextArea<S, PS> extends Region
                 () -> content.getText(internalSelection.getValue()),
                 internalSelection, content.getParagraphs()).suspendable();
 
-        omniSuspendable = Suspendable.combine(
+        Suspendable omniSuspendable = Suspendable.combine(
                 content.beingUpdatedProperty(), // must be first, to be the last one to release
                 text,
                 length,
@@ -643,6 +641,7 @@ public class StyledTextArea<S, PS> extends Region
 
                 // paragraphs to be released first
                 paragraphs);
+        content.addSuspendable(omniSuspendable);
 
         this.setBackground(new Background(new BackgroundFill(Color.WHITE, CornerRadii.EMPTY, Insets.EMPTY)));
         getStyleClass().add("styled-text-area");
@@ -1029,27 +1028,27 @@ public class StyledTextArea<S, PS> extends Region
      * Sets style for the given character range.
      */
     public void setStyle(int from, int to, S style) {
-        try(Guard g = omniSuspendable.suspend()) {
-            content.setStyle(from, to, style);
-        }
+        content.suspendAll();
+        content.setStyle(from, to, style);
+        content.unsuspendAll();
     }
 
     /**
      * Sets style for the whole paragraph.
      */
     public void setStyle(int paragraph, S style) {
-        try(Guard g = omniSuspendable.suspend()) {
-            content.setStyle(paragraph, style);
-        }
+        content.suspendAll();
+        content.setStyle(paragraph, style);
+        content.unsuspendAll();
     }
 
     /**
      * Sets style for the given range relative in the given paragraph.
      */
     public void setStyle(int paragraph, int from, int to, S style) {
-        try(Guard g = omniSuspendable.suspend()) {
-            content.setStyle(paragraph, from, to, style);
-        }
+        content.suspendAll();
+        content.setStyle(paragraph, from, to, style);
+        content.unsuspendAll();
     }
 
     /**
@@ -1063,9 +1062,9 @@ public class StyledTextArea<S, PS> extends Region
      * but the actual implementation is more efficient.
      */
     public void setStyleSpans(int from, StyleSpans<? extends S> styleSpans) {
-        try(Guard g = omniSuspendable.suspend()) {
-            content.setStyleSpans(from, styleSpans);
-        }
+        content.suspendAll();
+        content.setStyleSpans(from, styleSpans);
+        content.unsuspendAll();
     }
 
     /**
@@ -1079,18 +1078,18 @@ public class StyledTextArea<S, PS> extends Region
      * but the actual implementation is more efficient.
      */
     public void setStyleSpans(int paragraph, int from, StyleSpans<? extends S> styleSpans) {
-        try(Guard g = omniSuspendable.suspend()) {
-            content.setStyleSpans(paragraph, from, styleSpans);
-        }
+        content.suspendAll();
+        content.setStyleSpans(paragraph, from, styleSpans);
+        content.unsuspendAll();
     }
 
     /**
      * Sets style for the whole paragraph.
      */
     public void setParagraphStyle(int paragraph, PS paragraphStyle) {
-        try(Guard g = omniSuspendable.suspend()) {
-            content.setParagraphStyle(paragraph, paragraphStyle);
-        }
+        content.suspendAll();
+        content.setParagraphStyle(paragraph, paragraphStyle);
+        content.unsuspendAll();
     }
 
     /**
@@ -1131,15 +1130,15 @@ public class StyledTextArea<S, PS> extends Region
 
     @Override
     public void replace(int start, int end, StyledDocument<S, PS> replacement) {
-        try(Guard g = omniSuspendable.suspend()) {
-            start = clamp(0, start, getLength());
-            end = clamp(0, end, getLength());
+        content.suspendAll();
+        start = clamp(0, start, getLength());
+        end = clamp(0, end, getLength());
 
-            content.replace(start, end, replacement);
+        content.replace(start, end, replacement);
 
-            int newCaretPos = start + replacement.length();
-            selectRange(newCaretPos, newCaretPos);
-        }
+        int newCaretPos = start + replacement.length();
+        selectRange(newCaretPos, newCaretPos);
+        content.unsuspendAll();
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -1040,27 +1040,27 @@ public class StyledTextArea<S, PS> extends Region
      * Sets style for the given character range.
      */
     public void setStyle(int from, int to, S style) {
-        content.suspendAll();
-        content.setStyle(from, to, style);
-        content.unsuspendAll();
+        try (Guard g = content.suspendAll()) {
+            content.setStyle(from, to, style);
+        }
     }
 
     /**
      * Sets style for the whole paragraph.
      */
     public void setStyle(int paragraph, S style) {
-        content.suspendAll();
-        content.setStyle(paragraph, style);
-        content.unsuspendAll();
+        try (Guard g = content.suspendAll()) {
+            content.setStyle(paragraph, style);
+        }
     }
 
     /**
      * Sets style for the given range relative in the given paragraph.
      */
     public void setStyle(int paragraph, int from, int to, S style) {
-        content.suspendAll();
-        content.setStyle(paragraph, from, to, style);
-        content.unsuspendAll();
+        try (Guard g = content.suspendAll()) {
+            content.setStyle(paragraph, from, to, style);
+        }
     }
 
     /**
@@ -1074,9 +1074,9 @@ public class StyledTextArea<S, PS> extends Region
      * but the actual implementation is more efficient.
      */
     public void setStyleSpans(int from, StyleSpans<? extends S> styleSpans) {
-        content.suspendAll();
-        content.setStyleSpans(from, styleSpans);
-        content.unsuspendAll();
+        try (Guard g = content.suspendAll()) {
+            content.setStyleSpans(from, styleSpans);
+        }
     }
 
     /**
@@ -1090,18 +1090,18 @@ public class StyledTextArea<S, PS> extends Region
      * but the actual implementation is more efficient.
      */
     public void setStyleSpans(int paragraph, int from, StyleSpans<? extends S> styleSpans) {
-        content.suspendAll();
-        content.setStyleSpans(paragraph, from, styleSpans);
-        content.unsuspendAll();
+        try (Guard g = content.suspendAll()) {
+            content.setStyleSpans(paragraph, from, styleSpans);
+        }
     }
 
     /**
      * Sets style for the whole paragraph.
      */
     public void setParagraphStyle(int paragraph, PS paragraphStyle) {
-        content.suspendAll();
-        content.setParagraphStyle(paragraph, paragraphStyle);
-        content.unsuspendAll();
+        try (Guard g = content.suspendAll()) {
+            content.setParagraphStyle(paragraph, paragraphStyle);
+        }
     }
 
     /**
@@ -1142,15 +1142,15 @@ public class StyledTextArea<S, PS> extends Region
 
     @Override
     public void replace(int start, int end, StyledDocument<S, PS> replacement) {
-        content.suspendAll();
-        start = clamp(0, start, getLength());
-        end = clamp(0, end, getLength());
+        try (Guard g = content.suspendAll()) {
+            start = clamp(0, start, getLength());
+            end = clamp(0, end, getLength());
 
-        content.replace(start, end, replacement);
+            content.replace(start, end, replacement);
 
-        int newCaretPos = start + replacement.length();
-        selectRange(newCaretPos, newCaretPos);
-        content.unsuspendAll();
+            int newCaretPos = start + replacement.length();
+            selectRange(newCaretPos, newCaretPos);
+        }
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -653,6 +653,7 @@ public class StyledTextArea<S, PS> extends Region
                 // paragraphs to be released first
                 paragraphs);
         content.addSuspendable(omniSuspendable);
+        manageSubscription(() -> content.removeSuspendable(omniSuspendable));
 
         this.setBackground(new Background(new BackgroundFill(Color.WHITE, CornerRadii.EMPTY, Insets.EMPTY)));
         getStyleClass().add("styled-text-area");

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -562,13 +562,7 @@ public class StyledTextArea<S, PS> extends Region
         plainTextChanges = content.plainTextChanges().pausable();
         richTextChanges = content.richChanges().pausable();
 
-        Binding<Boolean> notBeingUpdated = Bindings.not(beingUpdated);
-        manageBinding(notBeingUpdated);
-
-        EventStream<PlainTextChange> cloneChangesToContent = content
-                .plainTextChanges()
-                .retainLatestWhen(notBeingUpdated);
-        subscribeTo(cloneChangesToContent, plainTextChange -> {
+        subscribeTo(content.plainTextChanges(), plainTextChange -> {
             int changeLength = plainTextChange.getInserted().length() - plainTextChange.getRemoved().length();
             if (changeLength != 0) {
                 int indexOfChange = plainTextChange.getPosition();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -596,6 +596,13 @@ public class StyledTextArea<S, PS> extends Region
                                 : selectionEnd + changeLength;
                     }
                     selectRange(selectionStart, selectionEnd);
+                } else {
+                    // force-update internalSelection in case caret is
+                    // at the end of area and a character was deleted
+                    // (prevents a StringIndexOutOfBoundsException because
+                    // selection's end is one char farther than area's length).
+                    int internalCaretPos = internalCaretPosition.getValue();
+                    selectRange(internalCaretPos, internalCaretPos);
                 }
             }
         });

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -380,9 +380,8 @@ public class StyledTextArea<S, PS> extends Region
     }
 
     // beingUpdated
-    private final SuspendableNo beingUpdated = new SuspendableNo();
-    public ObservableBooleanValue beingUpdatedProperty() { return beingUpdated; }
-    public boolean isBeingUpdated() { return beingUpdated.get(); }
+    public ObservableBooleanValue beingUpdatedProperty() { return content.beingUpdatedProperty(); }
+    public boolean isBeingUpdated() { return content.isBeingUpdated(); }
 
     // total width estimate
     /**
@@ -628,7 +627,7 @@ public class StyledTextArea<S, PS> extends Region
                 internalSelection, content.getParagraphs()).suspendable();
 
         omniSuspendable = Suspendable.combine(
-                beingUpdated, // must be first, to be the last one to release
+                content.beingUpdatedProperty(), // must be first, to be the last one to release
                 text,
                 length,
                 caretPosition,
@@ -1380,6 +1379,6 @@ public class StyledTextArea<S, PS> extends Region
     }
 
     private Guard suspend(Suspendable... suspendables) {
-        return Suspendable.combine(beingUpdated, Suspendable.combine(suspendables)).suspend();
+        return Suspendable.combine(content.beingUpdatedProperty(), Suspendable.combine(suspendables)).suspend();
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -560,6 +560,9 @@ public class StyledTextArea<S, PS> extends Region
         plainTextChanges = content.plainTextChanges().pausable();
         richTextChanges = content.richChanges().pausable();
 
+        // when content is updated by an area, update the caret
+        // and selection ranges of all the other
+        // clones that also share this document
         subscribeTo(content.plainTextChanges(), plainTextChange -> {
             int changeLength = plainTextChange.getInserted().length() - plainTextChange.getRemoved().length();
             if (changeLength != 0) {


### PR DESCRIPTION
I implemented the approach I described in #152 and for the most part it works. There are a few problems.
- If the user types in the original area quickly or if the user types even one character in the second line in the original area, the original area making the modification throws a StringIndexOutOfBoundsException.