### PR TITLE
Minor code refactoring to get rid of some compiler suggestions:

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
@@ -24,7 +24,7 @@ public class AreaFactory {
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
             S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle
     ) {
-        return new StyledTextArea<PS, S>(
+        return new StyledTextArea<>(
                 initialParagraphStyle, applyParagraphStyle,
                 initialTextStyle, applyStyle,
                 true);
@@ -44,7 +44,7 @@ public class AreaFactory {
             S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
             boolean preserveStyle
     ) {
-        return new StyledTextArea<PS, S>(
+        return new StyledTextArea<>(
                 initialParagraphStyle, applyParagraphStyle,
                 initialTextStyle, applyStyle,
                 preserveStyle);
@@ -60,7 +60,7 @@ public class AreaFactory {
 
     // Clones StyledTextArea
     public static <PS, S> StyledTextArea<PS, S> cloneStyleTextArea(StyledTextArea<PS, S> area) {
-        return new StyledTextArea<PS, S>(area.getInitialParagraphStyle(), area.getApplyParagraphStyle(),
+        return new StyledTextArea<>(area.getInitialParagraphStyle(), area.getApplyParagraphStyle(),
                 area.getInitialTextStyle(), area.getApplyStyle(),
                 area.getModel().getContent(), area.isPreserveStyle());
     }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CssProperties.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CssProperties.java
@@ -60,7 +60,7 @@ class CssProperties {
         public HighlightFillProperty(Object bean, Paint initialValue) {
             super(initialValue);
             this.bean = bean;
-            cssMetaData = new PropertyCssMetaData<Styleable, Paint>(
+            cssMetaData = new PropertyCssMetaData<>(
                     this, "-fx-highlight-fill",
                     StyleConverter.getPaintConverter(), initialValue);
         }
@@ -79,7 +79,7 @@ class CssProperties {
         public CssMetaData<? extends Styleable, Paint> getCssMetaData() {
             return cssMetaData;
         }
-    };
+    }
 
     static class HighlightTextFillProperty extends StyleableObjectProperty<Paint> {
         private final Object bean;
@@ -89,7 +89,7 @@ class CssProperties {
         public HighlightTextFillProperty(Object bean, Paint initialValue) {
             super(initialValue);
             this.bean = bean;
-            cssMetaData = new PropertyCssMetaData<Styleable, Paint>(
+            cssMetaData = new PropertyCssMetaData<>(
                     this, "-fx-highlight-text-fill",
                     StyleConverter.getPaintConverter(), initialValue);
         }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
@@ -1,19 +1,21 @@
 package org.fxmisc.richtext;
 
 
+import javafx.scene.text.TextFlow;
+
 /**
  * Text area that uses inline css to define style of text segments and paragraph segments.
  */
 public class InlineCssTextArea extends StyledTextArea<String, String> {
 
     public InlineCssTextArea() {
-        this(new EditableStyledDocument<String, String>("", ""));
+        this(new EditableStyledDocument<>("", ""));
     }
 
     public InlineCssTextArea(EditableStyledDocument<String, String> document) {
         super(
-                "", (paragraph, style) -> paragraph.setStyle(style),
-                "", (text, style) -> text.setStyle(style),
+                "", TextFlow::setStyle,
+                "", TextExt::setStyle,
                 document,
                 true
         );

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -197,9 +197,7 @@ class ParagraphBox<PS, S> extends Region {
 
         text.resizeRelocate(graphicWidth, 0, w - graphicWidth, h);
 
-        graphic.ifPresent(g -> {
-            g.resizeRelocate(graphicOffset.get(), 0, graphicWidth, h);
-        });
+        graphic.ifPresent(g -> g.resizeRelocate(graphicOffset.get(), 0, graphicWidth, h));
     }
 
     double getGraphicPrefWidth() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -9,6 +9,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.transformation.FilteredList;
 import javafx.geometry.Bounds;
+import javafx.geometry.Insets;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.control.IndexRange;
@@ -25,7 +26,7 @@ class ParagraphText<PS, S> extends TextFlowExt {
     // FIXME: changing it currently has not effect, because
     // Text.impl_selectionFillProperty().set(newFill) doesn't work
     // properly for Text node inside a TextFlow (as of JDK8-b100).
-    private final ObjectProperty<Paint> highlightTextFill = new SimpleObjectProperty<Paint>(Color.WHITE);
+    private final ObjectProperty<Paint> highlightTextFill = new SimpleObjectProperty<>(Color.WHITE);
     public ObjectProperty<Paint> highlightTextFillProperty() {
         return highlightTextFill;
     }
@@ -64,8 +65,8 @@ class ParagraphText<PS, S> extends TextFlowExt {
 
         selection.addListener((obs, old, sel) -> requestLayout());
 
-        Val<Double> leftInset = Val.map(insetsProperty(), ins -> ins.getLeft());
-        Val<Double> topInset = Val.map(insetsProperty(), ins -> ins.getTop());
+        Val<Double> leftInset = Val.map(insetsProperty(), Insets::getLeft);
+        Val<Double> topInset = Val.map(insetsProperty(), Insets::getTop);
 
         // selection highlight
         selectionShape.setManaged(false);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
@@ -25,7 +25,7 @@ public class StyleClassedTextArea extends StyledTextArea<Collection<String>, Col
     }
     public StyleClassedTextArea(boolean preserveStyle) {
         this(
-                new EditableStyledDocument<Collection<String>, Collection<String>>(
+                new EditableStyledDocument<>(
                     Collections.<String>emptyList(), Collections.<String>emptyList()
                 ), preserveStyle);
     }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleSpans.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleSpans.java
@@ -158,7 +158,7 @@ public interface StyleSpans<S> extends Iterable<StyleSpan<S>>, TwoDimensional {
     }
 
     default Stream<S> styleStream() {
-        return stream().map(span -> span.getStyle());
+        return stream().map(StyleSpan::getStyle);
     }
 
     default Stream<StyleSpan<S>> stream() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleSpansBuilder.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleSpansBuilder.java
@@ -25,7 +25,7 @@ public class StyleSpansBuilder<S> {
         @Override
         public int length() {
             if(length == -1) {
-                length = spans.stream().mapToInt(span -> span.getLength()).sum();
+                length = spans.stream().mapToInt(StyleSpan::getLength).sum();
             }
 
             return length;
@@ -174,7 +174,7 @@ public class StyleSpansBuilder<S> {
 
 abstract class StyleSpansBase<S> implements StyleSpans<S> {
     protected final TwoLevelNavigator navigator = new TwoLevelNavigator(
-            () -> getSpanCount(),
+            this::getSpanCount,
             i -> getStyleSpan(i).getLength());
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledDocumentBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledDocumentBase.java
@@ -20,7 +20,7 @@ implements StyledDocument<PS, S> {
     protected StyledDocumentBase(L paragraphs) {
         this.paragraphs = paragraphs;
         navigator = new TwoLevelNavigator(
-                () -> paragraphs.size(),
+                paragraphs::size,
                 i -> paragraphs.get(i).length() + (i == paragraphs.size() - 1 ? 0 : 1));
     }
 
@@ -79,7 +79,7 @@ implements StyledDocument<PS, S> {
         return sub(
                 start, end,
                 p -> p,
-                (p, a, b) -> p.subSequence(a, b),
+                Paragraph::subSequence,
                 (List<Paragraph<PS, S>> pars) -> new ReadOnlyStyledDocument<>(pars, ADOPT));
     }
 
@@ -172,7 +172,7 @@ implements StyledDocument<PS, S> {
             subSpans.add(endPar.getStyleSpans(0, end.getMinor()));
         }
 
-        int n = subSpans.stream().mapToInt(sr -> sr.getSpanCount()).sum();
+        int n = subSpans.stream().mapToInt(StyleSpans::getSpanCount).sum();
         StyleSpansBuilder<S> builder = new StyleSpansBuilder<>(n);
         for(StyleSpans<S> spans: subSpans) {
             for(StyleSpan<S> span: spans) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledText.java
@@ -24,21 +24,21 @@ public class StyledText<S> {
     }
 
     public StyledText<S> subSequence(int start, int end) {
-        return new StyledText<S>(text.substring(start, end), style);
+        return new StyledText<>(text.substring(start, end), style);
     }
 
     public StyledText<S> subSequence(int start) {
-        return new StyledText<S>(text.substring(start), style);
+        return new StyledText<>(text.substring(start), style);
     }
 
     public StyledText<S> append(String str) {
-        return new StyledText<S>(text + str, style);
+        return new StyledText<>(text + str, style);
     }
 
     public StyledText<S> spliced(int from, int to, CharSequence replacement) {
         String left = text.substring(0, from);
         String right = text.substring(to);
-        return new StyledText<S>(left + replacement + right, style);
+        return new StyledText<>(left + replacement + right, style);
     }
 
     public S getStyle() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -317,7 +317,7 @@ public class StyledTextArea<PS, S> extends Region
     @Override public final ObservableValue<String> textProperty() { return model.textProperty(); }
 
     // rich text
-    @Override public final StyledDocument<PS, S> getDocument() { return model.getDocument(); };
+    @Override public final StyledDocument<PS, S> getDocument() { return model.getDocument(); }
 
     // length
     @Override public final int getLength() { return model.getLength(); }
@@ -475,12 +475,12 @@ public class StyledTextArea<PS, S> extends Region
         this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, true);
     }
 
-    public <C> StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
                               S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
                               boolean preserveStyle
     ) {
         this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle,
-                new EditableStyledDocument<PS, S>(initialParagraphStyle, initialTextStyle), preserveStyle);
+                new EditableStyledDocument<>(initialParagraphStyle, initialTextStyle), preserveStyle);
     }
 
     /**
@@ -500,7 +500,7 @@ public class StyledTextArea<PS, S> extends Region
                           S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
                           EditableStyledDocument<PS, S> document, boolean preserveStyle
     ) {
-        this.model = new StyledTextAreaModel<PS, S>(initialParagraphStyle, initialTextStyle, document, preserveStyle);
+        this.model = new StyledTextAreaModel<>(initialParagraphStyle, initialTextStyle, document, preserveStyle);
         this.applyStyle = applyStyle;
         this.applyParagraphStyle = applyParagraphStyle;
 
@@ -521,7 +521,6 @@ public class StyledTextArea<PS, S> extends Region
                     Cell<Paragraph<PS, S>, ParagraphBox<PS, S>> cell = createCell(
                             par,
                             applyStyle,
-                            initialParagraphStyle,
                             applyParagraphStyle);
                     nonEmptyCells.add(cell.getNode());
                     return cell.beforeReset(() -> nonEmptyCells.remove(cell.getNode()))
@@ -1023,7 +1022,6 @@ public class StyledTextArea<PS, S> extends Region
     private Cell<Paragraph<PS, S>, ParagraphBox<PS, S>> createCell(
             Paragraph<PS, S> paragraph,
             BiConsumer<? super TextExt, S> applyStyle,
-            PS initialParagraphStyle,
             BiConsumer<TextFlow, PS> applyParagraphStyle) {
 
         ParagraphBox<PS, S> box = new ParagraphBox<>(paragraph, applyParagraphStyle, applyStyle);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaModel.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaModel.java
@@ -105,7 +105,7 @@ public class StyledTextAreaModel<PS, S>
     @Override public final ObservableValue<String> textProperty() { return text; }
 
     // rich text
-    @Override public final StyledDocument<PS, S> getDocument() { return content.snapshot(); };
+    @Override public final StyledDocument<PS, S> getDocument() { return content.snapshot(); }
 
     // length
     private final SuspendableVal<Integer> length;
@@ -212,8 +212,6 @@ public class StyledTextAreaModel<PS, S>
     private final boolean preserveStyle;
     protected final boolean isPreserveStyle() { return preserveStyle; }
 
-    private final Suspendable omniSuspendable;
-
 
     /* ********************************************************************** *
      *                                                                        *
@@ -233,10 +231,10 @@ public class StyledTextAreaModel<PS, S>
         this(initialParagraphStyle, initialTextStyle, true);
     }
 
-    public <C> StyledTextAreaModel(PS initialParagraphStyle, S initialTextStyle, boolean preserveStyle
+    public StyledTextAreaModel(PS initialParagraphStyle, S initialTextStyle, boolean preserveStyle
     ) {
         this(initialParagraphStyle, initialTextStyle,
-                new EditableStyledDocument<PS, S>(initialParagraphStyle, initialTextStyle), preserveStyle);
+                new EditableStyledDocument<>(initialParagraphStyle, initialTextStyle), preserveStyle);
     }
 
     /**
@@ -340,7 +338,7 @@ public class StyledTextAreaModel<PS, S>
                 () -> content.getText(internalSelection.getValue()),
                 internalSelection, content.getParagraphs()).suspendable();
 
-        omniSuspendable = Suspendable.combine(
+        final Suspendable omniSuspendable = Suspendable.combine(
                 beingUpdated, // must be first, to be the last one to release
                 text,
                 length,
@@ -709,13 +707,13 @@ public class StyledTextAreaModel<PS, S>
 
     private UndoManager createPlainUndoManager(UndoManagerFactory factory) {
         Consumer<PlainTextChange> apply = change -> replaceText(change.getPosition(), change.getPosition() + change.getRemoved().length(), change.getInserted());
-        BiFunction<PlainTextChange, PlainTextChange, Optional<PlainTextChange>> merge = (change1, change2) -> change1.mergeWith(change2);
+        BiFunction<PlainTextChange, PlainTextChange, Optional<PlainTextChange>> merge = PlainTextChange::mergeWith;
         return factory.create(plainTextChanges(), PlainTextChange::invert, apply, merge);
     }
 
     private UndoManager createRichUndoManager(UndoManagerFactory factory) {
         Consumer<RichTextChange<PS, S>> apply = change -> replace(change.getPosition(), change.getPosition() + change.getRemoved().length(), change.getInserted());
-        BiFunction<RichTextChange<PS, S>, RichTextChange<PS, S>, Optional<RichTextChange<PS, S>>> merge = (change1, change2) -> change1.mergeWith(change2);
+        BiFunction<RichTextChange<PS, S>, RichTextChange<PS, S>, Optional<RichTextChange<PS, S>>> merge = RichTextChange<PS, S>::mergeWith;
         return factory.create(richChanges(), RichTextChange::invert, apply, merge);
     }
 


### PR DESCRIPTION
- Replace "(arg1, arg2) -> arg1.method(arg2)" lambdas with method references
- Removed explicit type since it can be inferred (e.g. "<PS, S>" --> "<>")
- Removed unneeded semi-colons
- Removed unused Type parameter "<C>"
- Removed `initialParagraphStyle` from `createCell()` since it isn't used there.
- Made `omniSuspendable` a local variable since suspending EditableStyledDocument's `beingUpdatedProperty()` suspends all clones' Suspendables now instead of `omniSuspendable`