### PR TITLE
Move UndoManager into EditableStyledDocument so that one UndoManager …

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CloneDemo.java
@@ -6,6 +6,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import org.fxmisc.richtext.AreaFactory;
@@ -22,8 +23,9 @@ public class CloneDemo extends Application {
         String selectedText = "selection";
         String text = "Edit the top area (original)\nand watch the (clone) bottom area's displayed text change and its " +
                 "selected text [" + selectedText + "] update itself accordingly.";
-        InlineCssTextArea area = AreaFactory.inlineCssTextArea(text);
+        InlineCssTextArea area = AreaFactory.inlineCssTextArea();
         InlineCssTextArea clone = AreaFactory.cloneInlineCssTextArea(area);
+        area.insertText(0, text);
 
         VBox vbox = new VBox(area, clone);
         vbox.setSpacing(10);
@@ -51,14 +53,6 @@ public class CloneDemo extends Application {
         Label areaLabel = new Label("Original Area: ");
         Label cloneLabel = new Label("Cloned Area: ");
 
-        // set up Buttons that programmatically change area but not clone
-        Button deleteLastThreeChars = new Button("Click to Delete the previous 3 chars.");
-        deleteLastThreeChars.setOnAction((ae) -> {
-            for (int i = 0; i <= 2; i++) {
-                area.deletePreviousChar();
-            }
-        });
-
         // finish GUI
         GridPane grid = new GridPane();
         // add area content to first row
@@ -74,10 +68,27 @@ public class CloneDemo extends Application {
         grid.setHgap(10);
         grid.setVgap(4);
 
+
+        // set up Buttons that programmatically alter content area but not clone
+        Button areaDelPrevChar = new Button("Area::deletePreviousChar");
+        areaDelPrevChar.setOnAction((ae) -> area.deletePreviousChar() );
+
+        Button areaUndo = new Button("Area::undo");
+        areaUndo.setOnAction((ae) -> area.undo());
+        Button areaRedo = new Button("Area::redo");
+        areaRedo.setOnAction((ae) -> area.redo());
+
+        Button cloneUndo = new Button("Clone::undo");
+        cloneUndo.setOnAction((ae) -> clone.undo());
+        Button cloneRedo = new Button("Clone::redo");
+        cloneRedo.setOnAction((ae) -> clone.redo());
+
+        HBox buttonBox = new HBox(areaDelPrevChar, areaUndo, areaRedo, cloneUndo, cloneRedo);
+
         BorderPane pane = new BorderPane();
         pane.setCenter(vbox);
         pane.setTop(grid);
-        pane.setBottom(deleteLastThreeChars);
+        pane.setBottom(buttonBox);
 
         Scene scene = new Scene(pane, 800, 500);
         primaryStage.setScene(scene);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
@@ -61,8 +61,7 @@ public class AreaFactory {
     // Clones StyledTextArea
     public static <PS, S> StyledTextArea<PS, S> cloneStyleTextArea(StyledTextArea<PS, S> area) {
         return new StyledTextArea<>(area.getInitialParagraphStyle(), area.getApplyParagraphStyle(),
-                area.getInitialTextStyle(), area.getApplyStyle(),
-                area.getModel().getContent(), area.isPreserveStyle());
+                area.getInitialTextStyle(), area.getApplyStyle(), area.getModel().getContent());
     }
 
     // Embeds cloned StyledTextArea
@@ -105,7 +104,7 @@ public class AreaFactory {
 
     // Clones StyleClassedTextArea
     public static StyleClassedTextArea cloneStyleClassedTextArea(StyleClassedTextArea area) {
-        return new StyleClassedTextArea(area.getModel().getContent(), area.isPreserveStyle());
+        return new StyleClassedTextArea(area.getModel().getContent());
     }
 
     // Embeds cloned StyleClassedTextArea

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
@@ -21,7 +21,7 @@ public class CodeArea extends StyleClassedTextArea {
     }
 
     public CodeArea(EditableStyledDocument<Collection<String>, Collection<String>> document) {
-        super(document, false);
+        super(document);
     }
 
     public CodeArea() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -237,11 +237,7 @@ final class EditableStyledDocument<PS, S> extends StyledDocumentBase<PS, S, Obse
         replaceContent(start, end, richTextChange.getInserted());
 
         // complete the change events
-        plainUndoRedos.push(new PlainTextChange(
-                richTextChange.getPosition(),
-                richTextChange.getRemoved().getText(),
-                richTextChange.getInserted().getText())
-        );
+        plainUndoRedos.push(richTextChange.toPlainTextChange());
         richUndoRedos.push(richTextChange);
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
@@ -9,15 +9,14 @@ import javafx.scene.text.TextFlow;
 public class InlineCssTextArea extends StyledTextArea<String, String> {
 
     public InlineCssTextArea() {
-        this(new EditableStyledDocument<>("", ""));
+        this(new EditableStyledDocument<>("", "", true));
     }
 
     public InlineCssTextArea(EditableStyledDocument<String, String> document) {
         super(
                 "", TextFlow::setStyle,
                 "", TextExt::setStyle,
-                document,
-                true
+                document
         );
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/RichTextChange.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/RichTextChange.java
@@ -41,7 +41,4 @@ public class RichTextChange<PS, S> extends TextChange<StyledDocument<PS, S>, Ric
                 "}";
     }
 
-    public final PlainTextChange toPlainTextChange() {
-        return new PlainTextChange(position, removed.getText(), inserted.getText());
-    }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/RichTextChange.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/RichTextChange.java
@@ -40,4 +40,8 @@ public class RichTextChange<PS, S> extends TextChange<StyledDocument<PS, S>, Ric
                 "\tinserted: " + inserted + "\n" +
                 "}";
     }
+
+    public final PlainTextChange toPlainTextChange() {
+        return new PlainTextChange(position, removed.getText(), inserted.getText());
+    }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
@@ -10,12 +10,12 @@ import java.util.List;
  */
 public class StyleClassedTextArea extends StyledTextArea<Collection<String>, Collection<String>> {
 
-    public StyleClassedTextArea(EditableStyledDocument<Collection<String>, Collection<String>> document, boolean preserveStyle) {
+    public StyleClassedTextArea(EditableStyledDocument<Collection<String>, Collection<String>> document) {
         super(Collections.<String>emptyList(),
                 (paragraph, styleClasses) -> paragraph.getStyleClass().addAll(styleClasses),
                 Collections.<String>emptyList(),
                 (text, styleClasses) -> text.getStyleClass().addAll(styleClasses),
-                document, preserveStyle
+                document
         );
 
         setStyleCodecs(
@@ -24,10 +24,7 @@ public class StyleClassedTextArea extends StyledTextArea<Collection<String>, Col
         );
     }
     public StyleClassedTextArea(boolean preserveStyle) {
-        this(
-                new EditableStyledDocument<>(
-                    Collections.<String>emptyList(), Collections.<String>emptyList()
-                ), preserveStyle);
+        this(new EditableStyledDocument<>(Collections.<String>emptyList(), Collections.<String>emptyList(), preserveStyle));
     }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -480,7 +480,7 @@ public class StyledTextArea<PS, S> extends Region
                               boolean preserveStyle
     ) {
         this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle,
-                new EditableStyledDocument<>(initialParagraphStyle, initialTextStyle), preserveStyle);
+                new EditableStyledDocument<>(initialParagraphStyle, initialTextStyle, preserveStyle));
     }
 
     /**
@@ -492,15 +492,7 @@ public class StyledTextArea<PS, S> extends Region
                           S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
                           EditableStyledDocument<PS, S> document
     ) {
-        this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, document, true);
-
-    }
-
-    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                          S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
-                          EditableStyledDocument<PS, S> document, boolean preserveStyle
-    ) {
-        this.model = new StyledTextAreaModel<>(initialParagraphStyle, initialTextStyle, document, preserveStyle);
+        this.model = new StyledTextAreaModel<>(initialParagraphStyle, initialTextStyle, document);
         this.applyStyle = applyStyle;
         this.applyParagraphStyle = applyParagraphStyle;
 

--- a/richtextfx/src/test/java/org/fxmisc/richtext/StyledTextAreaModelTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/StyledTextAreaModelTest.java
@@ -32,7 +32,7 @@ public class StyledTextAreaModelTest {
         // set up area with some styled text content
         boolean initialStyle = false;
         StyledTextAreaModel<String, Boolean> model = new StyledTextAreaModel<>(
-                "", initialStyle, new EditableStyledDocument<>("", initialStyle), true);
+                "", initialStyle, new EditableStyledDocument<>("", initialStyle, true));
         model.replaceText("testtest");
         model.setStyle(0, 8, true);
 
@@ -46,6 +46,86 @@ public class StyledTextAreaModelTest {
         // testing that undo/redo don't throw an exception
         model.undo();
         model.redo();
+    }
+
+    @Test
+    public void insureCloneUndoRedoWorks() {
+        // set up an are with some styled content
+        StyledTextAreaModel<String, String> area = new StyledTextAreaModel<>(
+                "", "", new EditableStyledDocument<>("", "", true));
+        String textStyle = "-fx-font-size: 30px;";
+
+        String styledText = "A really short text example.";
+        area.replace(0, 0, ReadOnlyStyledDocument.fromString(styledText, "", textStyle));
+
+        // create clones of initial model
+        StyledTextAreaModel<String, String> clone = new StyledTextAreaModel<>(
+                area.getInitialParagraphStyle(), area.getInitialTextStyle(),
+                area.getContent()
+        );
+
+        // area undo/redo works
+        area.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        area.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        // area undo / clone redo works
+        area.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        clone.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        // clone undo / area redo works
+        clone.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        area.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        // clone undo/redo works
+        clone.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        clone.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+    }
+
+    @Test
+    public void insureClonesUndoRedoWorksWhenInitialHasBeenDisposed() {
+        // set up an are with some styled content
+        StyledTextAreaModel<String, String> initialModel = new StyledTextAreaModel<>(
+                "", "", new EditableStyledDocument<>("", "", true));
+        String textStyle = "-fx-font-size: 30px;";
+
+        String beforeText = "A really long ";
+        String styledText = "text example just ";
+        String afterText = "for kicks.";
+        initialModel.replaceText(beforeText + styledText + afterText);
+        initialModel.setStyle(beforeText.length(), beforeText.length() + styledText.length(), textStyle);
+
+        // create clones of initial model
+        StyledTextAreaModel<String, String> clone1 = new StyledTextAreaModel<>(
+                initialModel.getInitialParagraphStyle(), initialModel.getInitialTextStyle(),
+                initialModel.getContent()
+        );
+
+        // call undo on initialModel and dispose of it
+        initialModel.undo();
+        initialModel.dispose();
+
+        // insure that redo on clones still works
+        clone1.redo();
     }
 
 }

--- a/richtextfx/src/test/java/org/fxmisc/richtext/StyledTextAreaModelTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/StyledTextAreaModelTest.java
@@ -1,11 +1,11 @@
 package org.fxmisc.richtext;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 public class StyledTextAreaModelTest {
 
@@ -49,7 +49,62 @@ public class StyledTextAreaModelTest {
     }
 
     @Test
-    public void insureCloneUndoRedoWorks() {
+    public void insureClonePlainUndoRedoWorks() {
+        // set up an are with some styled content
+        StyledTextAreaModel<String, String> area = new StyledTextAreaModel<>(
+                "", "", new EditableStyledDocument<>("", "", false));
+        String textStyle = "-fx-font-size: 30px;";
+
+        String styledText = "A really short text example.";
+        area.replace(0, 0, ReadOnlyStyledDocument.fromString(styledText, "", textStyle));
+
+        // create clones of initial model
+        StyledTextAreaModel<String, String> clone = new StyledTextAreaModel<>(
+                area.getInitialParagraphStyle(), area.getInitialTextStyle(),
+                area.getContent()
+        );
+
+        // area undo/redo works
+        System.out.println("Calling area::undo");
+        area.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        System.out.println("Calling area::redo");
+        area.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        // area undo / clone redo works
+        area.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        clone.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        // clone undo / area redo works
+        clone.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        area.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        // clone undo/redo works
+        clone.undo();
+        assertEquals("Area's text should be empty", "", area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+
+        clone.redo();
+        assertEquals("Area's text should match styledText", styledText, area.getText());
+        assertEquals(area.getDocument(), clone.getDocument());
+    }
+
+    @Test
+    public void insureCloneRichUndoRedoWorks() {
         // set up an are with some styled content
         StyledTextAreaModel<String, String> area = new StyledTextAreaModel<>(
                 "", "", new EditableStyledDocument<>("", "", true));
@@ -65,10 +120,12 @@ public class StyledTextAreaModelTest {
         );
 
         // area undo/redo works
+        System.out.println("Calling area::undo");
         area.undo();
         assertEquals("Area's text should be empty", "", area.getText());
         assertEquals(area.getDocument(), clone.getDocument());
 
+        System.out.println("Calling area::redo");
         area.redo();
         assertEquals("Area's text should match styledText", styledText, area.getText());
         assertEquals(area.getDocument(), clone.getDocument());


### PR DESCRIPTION
…is shared across multiple clones. Clones can be disposed without affecting access to the UndoManager.

See comments in #233 