### PR TITLE
Allow subclassing of StyledTextAreaModel to fix cloning issues

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -30,7 +30,7 @@ import org.reactfx.value.Var;
  * on styled text, but not worrying about additional aspects such as
  * caret or selection.
  */
-final class EditableStyledDocument<PS, S> extends StyledDocumentBase<PS, S, ObservableList<Paragraph<PS, S>>> {
+public final class EditableStyledDocument<PS, S> extends StyledDocumentBase<PS, S, ObservableList<Paragraph<PS, S>>> {
 
     /* ********************************************************************** *
      *                                                                        *

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -36,7 +36,7 @@ class ParagraphText<PS, S> extends TextFlowExt {
     public void setCaretPosition(int pos) { caretPosition.setValue(pos); }
     private final Val<Integer> clampedCaretPosition;
 
-    private final ObjectProperty<IndexRange> selection = new SimpleObjectProperty<>(StyledTextArea.EMPTY_RANGE);
+    private final ObjectProperty<IndexRange> selection = new SimpleObjectProperty<>(StyledTextAreaBase.EMPTY_RANGE);
     public ObjectProperty<IndexRange> selectionProperty() { return selection; }
     public void setSelection(IndexRange sel) { selection.set(sel); }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -1,0 +1,60 @@
+package org.fxmisc.richtext;
+
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Created by jordan on 1/26/16.
+ */
+public class StyledTextArea<PS, S> extends StyledTextAreaBase<PS, S, StyledTextAreaModel<PS, S>> {
+
+    /**
+     * Creates a text area with empty text content.
+     *
+     * @param initialTextStyle style to use in places where no other style is
+     * specified (yet).
+     * @param applyStyle function that, given a {@link Text} node and
+     * a style, applies the style to the text node. This function is
+     * used by the default skin to apply style to text nodes.
+     * @param initialParagraphStyle style to use in places where no other style is
+     * specified (yet).
+     * @param applyParagraphStyle function that, given a {@link TextFlow} node and
+     * a style, applies the style to the paragraph node. This function is
+     * used by the default skin to apply style to paragraph nodes.
+     */
+    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle
+    ) {
+        this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, true);
+    }
+
+    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+                              boolean preserveStyle
+    ) {
+        this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle,
+                new EditableStyledDocument<>(initialParagraphStyle, initialTextStyle), preserveStyle);
+    }
+
+    /**
+     * The same as {@link #StyledTextArea(Object, BiConsumer, Object, BiConsumer)} except that
+     * this constructor can be used to create another {@code StyledTextArea} object that
+     * shares the same {@link EditableStyledDocument}.
+     */
+    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+                              EditableStyledDocument<PS, S> document
+    ) {
+        this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, document, true);
+
+    }
+
+    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+                              EditableStyledDocument<PS, S> document, boolean preserveStyle
+    ) {
+        super(applyParagraphStyle, applyStyle, new StyledTextAreaModel<>(initialParagraphStyle, initialTextStyle, document, preserveStyle));
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBase.java
@@ -104,7 +104,7 @@ import org.reactfx.value.Var;
  *
  * @param <S> type of style that can be applied to text.
  */
-public class StyledTextAreaBase<PS, S> extends Region
+public class StyledTextAreaBase<PS, S, Model extends StyledTextAreaModel<PS, S>> extends Region
         implements
         TextEditingArea<PS, S>,
         EditActions<PS, S>,
@@ -411,12 +411,12 @@ public class StyledTextAreaBase<PS, S> extends Region
     /**
      * model
      */
-    private final StyledTextAreaModel<PS, S> model;
+    private final Model model;
 
     /**
      * @return this area's {@link StyledTextAreaModel}
      */
-    protected final StyledTextAreaModel<PS, S> getModel() {
+    protected final Model getModel() {
         return model;
     }
 
@@ -455,52 +455,10 @@ public class StyledTextAreaBase<PS, S> extends Region
      *                                                                        *
      * ********************************************************************** */
 
-    /**
-     * Creates a text area with empty text content.
-     *
-     * @param initialTextStyle style to use in places where no other style is
-     * specified (yet).
-     * @param applyStyle function that, given a {@link Text} node and
-     * a style, applies the style to the text node. This function is
-     * used by the default skin to apply style to text nodes.
-     * @param initialParagraphStyle style to use in places where no other style is
-     * specified (yet).
-     * @param applyParagraphStyle function that, given a {@link TextFlow} node and
-     * a style, applies the style to the paragraph node. This function is
-     * used by the default skin to apply style to paragraph nodes.
-     */
-    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle
+    public StyledTextAreaBase(BiConsumer<TextFlow, PS> applyParagraphStyle, BiConsumer<? super TextExt, S> applyStyle,
+                              Model model
     ) {
-        this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, true);
-    }
-
-    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
-                              boolean preserveStyle
-    ) {
-        this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle,
-                new EditableStyledDocument<>(initialParagraphStyle, initialTextStyle), preserveStyle);
-    }
-
-    /**
-     * The same as {@link #StyledTextAreaBase(Object, BiConsumer, Object, BiConsumer)} except that
-     * this constructor can be used to create another {@code StyledTextArea} object that
-     * shares the same {@link EditableStyledDocument}.
-     */
-    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
-                              EditableStyledDocument<PS, S> document
-    ) {
-        this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, document, true);
-
-    }
-
-    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
-                              EditableStyledDocument<PS, S> document, boolean preserveStyle
-    ) {
-        this.model = new StyledTextAreaModel<>(initialParagraphStyle, initialTextStyle, document, preserveStyle);
+        this.model = model;
         this.applyStyle = applyStyle;
         this.applyParagraphStyle = applyParagraphStyle;
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBase.java
@@ -104,7 +104,7 @@ import org.reactfx.value.Var;
  *
  * @param <S> type of style that can be applied to text.
  */
-public class StyledTextArea<PS, S> extends Region
+public class StyledTextAreaBase<PS, S> extends Region
         implements
         TextEditingArea<PS, S>,
         EditActions<PS, S>,
@@ -469,13 +469,13 @@ public class StyledTextArea<PS, S> extends Region
      * a style, applies the style to the paragraph node. This function is
      * used by the default skin to apply style to paragraph nodes.
      */
-    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                          S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle
+    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle
     ) {
         this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, true);
     }
 
-    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
                               S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
                               boolean preserveStyle
     ) {
@@ -484,21 +484,21 @@ public class StyledTextArea<PS, S> extends Region
     }
 
     /**
-     * The same as {@link #StyledTextArea(Object, BiConsumer, Object, BiConsumer)} except that
+     * The same as {@link #StyledTextAreaBase(Object, BiConsumer, Object, BiConsumer)} except that
      * this constructor can be used to create another {@code StyledTextArea} object that
      * shares the same {@link EditableStyledDocument}.
      */
-    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                          S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
-                          EditableStyledDocument<PS, S> document
+    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+                              EditableStyledDocument<PS, S> document
     ) {
         this(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, document, true);
 
     }
 
-    public StyledTextArea(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-                          S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
-                          EditableStyledDocument<PS, S> document, boolean preserveStyle
+    public StyledTextAreaBase(PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+                              S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+                              EditableStyledDocument<PS, S> document, boolean preserveStyle
     ) {
         this.model = new StyledTextAreaModel<>(initialParagraphStyle, initialTextStyle, document, preserveStyle);
         this.applyStyle = applyStyle;
@@ -1052,7 +1052,7 @@ public class StyledTextArea<PS, S> extends Region
             int idx = box.getIndex();
             return idx != -1
                     ? getParagraphSelection(idx)
-                    : StyledTextArea.EMPTY_RANGE;
+                    : StyledTextAreaBase.EMPTY_RANGE;
         }, selectionProperty(), box.indexProperty());
         box.selectionProperty().bind(cellSelection);
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -207,7 +207,7 @@ class StyledTextAreaBehavior implements Behavior {
      * Fields                                                                 *
      * ********************************************************************** */
 
-    private final StyledTextArea<?, ?> view;
+    private final StyledTextAreaBase<?, ?, ?> view;
 
     private final StyledTextAreaModel<?, ?> model;
 
@@ -238,7 +238,7 @@ class StyledTextAreaBehavior implements Behavior {
      * Constructors                                                           *
      * ********************************************************************** */
 
-    StyledTextAreaBehavior(StyledTextArea<?, ?> area) {
+    StyledTextAreaBehavior(StyledTextAreaBase<?, ?, ?> area) {
         this.view = area;
         this.model = area.getModel();
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaModel.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaModel.java
@@ -29,7 +29,7 @@ import org.reactfx.value.Val;
 import org.reactfx.value.Var;
 
 /**
- * Model for {@link StyledTextArea}
+ * Model for {@link StyledTextAreaBase}
  *
  * @param <S> type of style that can be applied to text.
  * @param <PS> type of style that can be applied to Paragraph


### PR DESCRIPTION
When I attempted to modify `StyledTextAreaBehavior` to account for the generics using this code:
````java
class StyledTextAreaBehavior
    <
        View extends StyledTextAreaBase<?, ?, Model>, 
        Model extends StyledTextAreaModel<?, ?>
    > 
implements Behavior {
    private final View view;

    private final Model model;

    StyledTextAreaBehavior(View area {
        this.view = area;
        this.model = area.getModel();
    }
}
````

I got compiler warnings about unchecked calls in various places. Since `StyledTextAreaBehavior`'s EventHandlers can be overridden, I decided to leave it out since it seems pointless to modify it any further.