### PR TITLE
Renamed confusing names for selection colors to more understandable names

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/CssProperties.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CssProperties.java
@@ -52,16 +52,16 @@ class CssProperties {
         }
     }
 
-    static class HighlightFillProperty extends StyleableObjectProperty<Paint> {
+    static class SelectionBackgroundFillProperty extends StyleableObjectProperty<Paint> {
         private final Object bean;
 
         private final CssMetaData<? extends Styleable, Paint> cssMetaData;
 
-        public HighlightFillProperty(Object bean, Paint initialValue) {
+        public SelectionBackgroundFillProperty(Object bean, Paint initialValue) {
             super(initialValue);
             this.bean = bean;
             cssMetaData = new PropertyCssMetaData<>(
-                    this, "-fx-highlight-fill",
+                    this, "-fx-selection-background-fill",
                     StyleConverter.getPaintConverter(), initialValue);
         }
 
@@ -72,7 +72,7 @@ class CssProperties {
 
         @Override
         public String getName() {
-            return "highlightFill";
+            return "selectionBackgroundFill";
         }
 
         @Override
@@ -81,16 +81,16 @@ class CssProperties {
         }
     }
 
-    static class HighlightTextFillProperty extends StyleableObjectProperty<Paint> {
+    static class SelectionForegroundFillProperty extends StyleableObjectProperty<Paint> {
         private final Object bean;
 
         private final CssMetaData<? extends Styleable, Paint> cssMetaData;
 
-        public HighlightTextFillProperty(Object bean, Paint initialValue) {
+        public SelectionForegroundFillProperty(Object bean, Paint initialValue) {
             super(initialValue);
             this.bean = bean;
             cssMetaData = new PropertyCssMetaData<>(
-                    this, "-fx-highlight-text-fill",
+                    this, "-fx-selection-foreground-fill",
                     StyleConverter.getPaintConverter(), initialValue);
         }
 
@@ -101,7 +101,7 @@ class CssProperties {
 
         @Override
         public String getName() {
-            return "highlightTextFill";
+            return "selectionForegroundFill";
         }
 
         @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -99,9 +99,9 @@ class ParagraphBox<PS, S> extends Region {
 
     public Property<Boolean> caretVisibleProperty() { return text.caretVisibleProperty(); }
 
-    public Property<Paint> highlightFillProperty() { return text.highlightFillProperty(); }
+    public Property<Paint> highlightFillProperty() { return text.selectionBackgroundFillProperty(); }
 
-    public Property<Paint> highlightTextFillProperty() { return text.highlightTextFillProperty(); }
+    public Property<Paint> highlightTextFillProperty() { return text.selectionForegroundFillProperty(); }
 
     public Var<Integer> caretPositionProperty() { return text.caretPositionProperty(); }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -26,9 +26,9 @@ class ParagraphText<PS, S> extends TextFlowExt {
     // FIXME: changing it currently has not effect, because
     // Text.impl_selectionFillProperty().set(newFill) doesn't work
     // properly for Text node inside a TextFlow (as of JDK8-b100).
-    private final ObjectProperty<Paint> highlightTextFill = new SimpleObjectProperty<>(Color.WHITE);
-    public ObjectProperty<Paint> highlightTextFillProperty() {
-        return highlightTextFill;
+    private final ObjectProperty<Paint> selectionForegroundFill = new SimpleObjectProperty<>(Color.WHITE);
+    public ObjectProperty<Paint> selectionForegroundFillProperty() {
+        return selectionForegroundFill;
     }
 
     private final Var<Integer> caretPosition = Var.newSimpleVar(0);
@@ -84,8 +84,8 @@ class ParagraphText<PS, S> extends TextFlowExt {
         caretShape.layoutYProperty().bind(topInset);
         getChildren().add(caretShape);
 
-        // XXX: see the note at highlightTextFill
-//        highlightTextFill.addListener(new ChangeListener<Paint>() {
+        // XXX: see the note at selectionForegroundFill
+//        selectionForegroundFill.addListener(new ChangeListener<Paint>() {
 //            @Override
 //            public void changed(ObservableValue<? extends Paint> observable,
 //                    Paint oldFill, Paint newFill) {
@@ -102,7 +102,7 @@ class ParagraphText<PS, S> extends TextFlowExt {
             applyStyle.accept(t, segment.getStyle());
 
             // XXX: binding selectionFill to textFill,
-            // see the note at highlightTextFill
+            // see the note at selectionForegroundFill
             t.impl_selectionFillProperty().bind(t.fillProperty());
 
             getChildren().add(t);
@@ -127,7 +127,7 @@ class ParagraphText<PS, S> extends TextFlowExt {
         return caretVisible;
     }
 
-    public ObjectProperty<Paint> highlightFillProperty() {
+    public ObjectProperty<Paint> selectionBackgroundFillProperty() {
         return selectionShape.fillProperty();
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -138,16 +138,16 @@ public class StyledTextArea<PS, S> extends Region
      * ********************************************************************** */
 
     /**
-     * Background fill for highlighted text.
+     * Background fill for selected text.
      */
-    private final StyleableObjectProperty<Paint> highlightFill
-            = new CssProperties.HighlightFillProperty(this, Color.DODGERBLUE);
+    private final StyleableObjectProperty<Paint> selectionBackgroundFill
+            = new CssProperties.SelectionBackgroundFillProperty(this, Color.DODGERBLUE);
 
     /**
-     * Text color for highlighted text.
+     * Foreground fill (text letter's color) for selected text.
      */
-    private final StyleableObjectProperty<Paint> highlightTextFill
-            = new CssProperties.HighlightTextFillProperty(this, Color.WHITE);
+    private final StyleableObjectProperty<Paint> selectionForegroundFill
+            = new CssProperties.SelectionForegroundFillProperty(this, Color.WHITE);
 
     // editable property
     /**
@@ -1032,8 +1032,8 @@ public class StyledTextArea<PS, S> extends Region
 
         ParagraphBox<PS, S> box = new ParagraphBox<>(paragraph, applyParagraphStyle, applyStyle);
 
-        box.highlightFillProperty().bind(highlightFill);
-        box.highlightTextFillProperty().bind(highlightTextFill);
+        box.highlightFillProperty().bind(selectionBackgroundFill);
+        box.highlightTextFillProperty().bind(selectionForegroundFill);
         box.wrapTextProperty().bind(wrapTextProperty());
         box.graphicFactoryProperty().bind(paragraphGraphicFactoryProperty());
         box.graphicOffset.bind(virtualFlow.breadthOffsetProperty());


### PR DESCRIPTION
This will lead to some breaking changes in people's CSS files, but since we're already breaking stuff in the new release, might as well do it here.