### PR TITLE
Allow subclasses of StyledTextArea (and its package's subclasses) to clone themselves

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/EditableStyledDocument.java
@@ -30,7 +30,7 @@ import org.reactfx.value.Var;
  * on styled text, but not worrying about additional aspects such as
  * caret or selection.
  */
-final class EditableStyledDocument<PS, S> extends StyledDocumentBase<PS, S, ObservableList<Paragraph<PS, S>>> {
+public final class EditableStyledDocument<PS, S> extends StyledDocumentBase<PS, S, ObservableList<Paragraph<PS, S>>> {
 
     /* ********************************************************************** *
      *                                                                        *

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaModel.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaModel.java
@@ -33,7 +33,7 @@ import org.reactfx.value.Var;
  * @param <S> type of style that can be applied to text.
  * @param <PS> type of style that can be applied to Paragraph
  */
-class StyledTextAreaModel<PS, S>
+public final class StyledTextAreaModel<PS, S>
         implements
         TextEditingArea<PS, S>,
         EditActions<PS, S>,
@@ -189,19 +189,19 @@ class StyledTextAreaModel<PS, S>
      * the same document (Model).
      * @return this area's {@link EditableStyledDocument}
      */
-    protected final EditableStyledDocument<PS, S> getContent() { return content; }
+    public final EditableStyledDocument<PS, S> getContent() { return content; }
 
     /**
      * Style used by default when no other style is provided.
      */
     private final S initialTextStyle;
-    protected final S getInitialTextStyle() { return initialTextStyle; }
+    public final S getInitialTextStyle() { return initialTextStyle; }
 
     /**
      * Style used by default when no other style is provided.
      */
     private final PS initialParagraphStyle;
-    protected final PS getInitialParagraphStyle() { return initialParagraphStyle; }
+    public final PS getInitialParagraphStyle() { return initialParagraphStyle; }
 
     /**
      * Indicates whether style should be preserved on undo/redo,
@@ -209,7 +209,7 @@ class StyledTextAreaModel<PS, S>
      * TODO: Currently, only undo/redo respect this flag.
      */
     private final boolean preserveStyle;
-    protected final boolean isPreserveStyle() { return preserveStyle; }
+    public final boolean isPreserveStyle() { return preserveStyle; }
 
 
     /* ********************************************************************** *


### PR DESCRIPTION
I know we made `StyledTextAreaModel` package-private in the last commit. However, I came across an issue relating to cloning subclasses. Because the model is no longer public, a subclass cannot access the model to get the `EditableStyledDocument` as its clone's argument. The below approach would work if `StyledTextAreaModel` was public but `EditableStyledDocument` was not public:
````java
// assuming this constructor exists:
public SomeArea(SomeArea areaToClone) {
  // super = InlineCssTextArea(EditableStyledDocument<String, String> doc);
  super(
    area
      // since the model is package-private, "getModel()" isn't accessible!
      .getModel() 
      .getContent()
  );
}

// this code will not work if the model is package-private
SomeArea area = // area that extends InlineCssTextArea
SomeArea clone = new SomeArea(area);
````

However, if that approach is followed (`EditableSyledDocument` is not public) another issue arises: one cannot use it as a Constructor parameter....
````java
public class SomeArea extends InlineCssTextArea {
                // Compiler: cannot resolve object "EditableStyledDocument"
    public SomeArea(EditableStyledDocument<String,String> doc) {
        super(doc);
    }

}
````
... which means subclasses of subclasses cannot clone themselves
````java
public class AnotherArea extends SomeArea {

    public AnotherArea(EditableStyledDocument<String, String> doc) {
        // Compiler: "this constructor doesn't exist: 'SomeArea(EditableStyledDocument)' "
        super(doc);
}
````

So, I made `StyledTextAreaModel` **public** (to get around this issue) **and final** (so that it still can't be subclassed). Additionally, I made the methods relating to styles (e.g. `getInitialTextStyle()`) public so a proper clone can be created.
Finally, I made `EditableStyledDocument` public but did not change anything else (it was already `final` so there was no need to change anything there).