### PR TITLE
Remove javadoc for x, y params to get rid of warnings

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -663,8 +663,6 @@ public class StyledTextArea<PS, S> extends Region
      *         area.moveTo(characterPosition, SelectionPolicy.CLEAR);
      *     }}
      * </pre>
-     * @param x
-     * @param y
      */
     public CharacterHit hit(double x, double y) {
         VirtualFlowHit<Cell<Paragraph<PS, S>, ParagraphBox<PS, S>>> hit = virtualFlow.hit(x, y);


### PR DESCRIPTION
I wasn't sure what to put for the parameter description. However, I thought the example given in the javadoc would explain any further questions developers might have. So, I'm guessing it's ok to not describe the parameters.