### PR TITLE
Allow modification of area before embedding it into a VirtualizedScrollPane

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywords.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywords.java
@@ -11,6 +11,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 import org.fxmisc.flowless.VirtualizedScrollPane;
+import org.fxmisc.richtext.AreaFactory;
 import org.fxmisc.richtext.CodeArea;
 import org.fxmisc.richtext.LineNumberFactory;
 import org.fxmisc.richtext.StyleSpans;
@@ -79,17 +80,18 @@ public class JavaKeywords extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        CodeArea codeArea = new CodeArea();
-        codeArea.setParagraphGraphicFactory(LineNumberFactory.get(codeArea));
+        VirtualizedScrollPane<CodeArea> virtualizedScrollPane = AreaFactory.embeddedCodeArea(codeArea -> {
+            codeArea.setParagraphGraphicFactory(LineNumberFactory.get(codeArea));
 
-        codeArea.richChanges()
-                .filter(ch -> !ch.getInserted().equals(ch.getRemoved())) // XXX
-                .subscribe(change -> {
-                    codeArea.setStyleSpans(0, computeHighlighting(codeArea.getText()));
-                });
-        codeArea.replaceText(0, 0, sampleCode);
+            codeArea.richChanges()
+                    .filter(ch -> !ch.getInserted().equals(ch.getRemoved())) // XXX
+                    .subscribe(change -> {
+                        codeArea.setStyleSpans(0, computeHighlighting(codeArea.getText()));
+                    });
+            codeArea.replaceText(0, 0, sampleCode);
 
-        Scene scene = new Scene(new StackPane(new VirtualizedScrollPane<>(codeArea)), 600, 400);
+        });
+        Scene scene = new Scene(new StackPane(virtualizedScrollPane), 600, 400);
         scene.getStylesheets().add(JavaKeywordsAsync.class.getResource("java-keywords.css").toExternalForm());
         primaryStage.setScene(scene);
         primaryStage.setTitle("Java Keywords Demo");

--- a/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/AreaFactory.java
@@ -4,14 +4,28 @@ import javafx.scene.text.TextFlow;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 /**
  * AreaFactory is a convenience class used to create StyledTextArea
  * and any of its subclasses. and optionally embed them
  * into a {@link VirtualizedScrollPane}.
- *
  */
 public class AreaFactory {
+
+    /*
+        Area
+            new instance
+            new instance; embedded
+            new instance with modifier; embedded
+            (repeat for all non-clone constructors)
+
+            clone
+            embed a clone of area
+            embed a clone of area with modifier
+            embed a clone of area that is itself embedded
+            embed a clone of area that is itself embedded with modifier
+     */
 
     /* ********************************************************************** *
      *                                                                        *
@@ -19,62 +33,83 @@ public class AreaFactory {
      *                                                                        *
      * ********************************************************************** */
 
-    // StyledTextArea 1
     public static <PS, S> StyledTextArea<PS, S> styledTextArea(
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-            S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle
-    ) {
-        return new StyledTextArea<>(
-                initialParagraphStyle, applyParagraphStyle,
-                initialTextStyle, applyStyle,
-                true);
+            S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle) {
+        return new StyledTextArea<>(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle);
     }
 
-    // Embeds StyledTextArea 1
-    public static <PS, S>VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedStyledTextArea(
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedStyledTextArea(
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
             S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle
     ) {
         return new VirtualizedScrollPane<>(styledTextArea(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle));
     }
 
-    // StyledTextArea 2
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedStyledTextArea(
+            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+            S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+            Consumer<StyledTextArea<PS, S>> modifier
+    ) {
+        StyledTextArea<PS, S> area = styledTextArea(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle);
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
+    }
+
     public static <PS, S> StyledTextArea<PS, S> styledTextArea(
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
             S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
             boolean preserveStyle
     ) {
-        return new StyledTextArea<>(
-                initialParagraphStyle, applyParagraphStyle,
-                initialTextStyle, applyStyle,
-                preserveStyle);
+        return new StyledTextArea<>(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, preserveStyle);
     }
 
-    // Embeds StyledTextArea 2
-    public static <PS, S>VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedStyledTextArea(
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedStyledTextArea(
             PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
-            S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle, boolean preserveStyle
+            S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+            boolean preserveStyle
     ) {
         return new VirtualizedScrollPane<>(styledTextArea(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, preserveStyle));
     }
 
-    // Clones StyledTextArea
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedStyledTextArea(
+            PS initialParagraphStyle, BiConsumer<TextFlow, PS> applyParagraphStyle,
+            S initialTextStyle, BiConsumer<? super TextExt, S> applyStyle,
+            boolean preserveStyle, Consumer<StyledTextArea<PS, S>> modifier
+    ) {
+        StyledTextArea<PS, S> area = styledTextArea(initialParagraphStyle, applyParagraphStyle, initialTextStyle, applyStyle, preserveStyle);
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
+    }
+
     public static <PS, S> StyledTextArea<PS, S> cloneStyleTextArea(StyledTextArea<PS, S> area) {
         return new StyledTextArea<>(area.getInitialParagraphStyle(), area.getApplyParagraphStyle(),
                 area.getInitialTextStyle(), area.getApplyStyle(),
                 area.getContent(), area.isPreserveStyle());
     }
 
-    // Embeds cloned StyledTextArea
-    public static <PS, S>VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedClonedStyledTextArea(StyledTextArea<PS, S> area) {
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedClonedStyledTextArea(StyledTextArea<PS, S> area) {
         return new VirtualizedScrollPane<>(cloneStyleTextArea(area));
     }
 
-    // Embeds a cloned StyledTextArea from an embedded StyledTextArea
-    public static <PS, S>VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedClonedStyledTextArea(
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedClonedStyledTextArea(StyledTextArea<PS, S> area,
+                                                                                                    Consumer<StyledTextArea<PS, S>> modifier) {
+        StyledTextArea<PS, S> clone = cloneStyleTextArea(area);
+        modifier.accept(clone);
+        return new VirtualizedScrollPane<>(clone);
+    }
+
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedClonedStyledTextArea(
             VirtualizedScrollPane<StyledTextArea<PS, S>> virtualizedScrollPaneWithArea
     ) {
         return embeddedClonedStyledTextArea(virtualizedScrollPaneWithArea.getContent());
+    }
+
+    public static <PS, S> VirtualizedScrollPane<StyledTextArea<PS, S>> embeddedClonedStyledTextArea(
+            VirtualizedScrollPane<StyledTextArea<PS, S>> virtualizedScrollPaneWithArea,
+            Consumer<StyledTextArea<PS, S>> modifier
+    ) {
+        return embeddedClonedStyledTextArea(virtualizedScrollPaneWithArea.getContent(), modifier);
     }
 
     /* ********************************************************************** *
@@ -83,41 +118,60 @@ public class AreaFactory {
      *                                                                        *
      * ********************************************************************** */
 
-    // StyleClassedTextArea 1
     public static StyleClassedTextArea styleClassedTextArea(boolean preserveStyle) {
         return new StyleClassedTextArea(preserveStyle);
     }
 
-    // Embeds StyleClassedTextArea  1
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea(boolean preserveStyle) {
         return new VirtualizedScrollPane<>(styleClassedTextArea(preserveStyle));
     }
 
-    // StyleClassedTextArea  2
-    public static StyleClassedTextArea styleClassedTextArea() {
-        return styleClassedTextArea(true);
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea(boolean preserveStyle, Consumer<StyleClassedTextArea> modifier) {
+        StyleClassedTextArea area = styleClassedTextArea(preserveStyle);
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
     }
 
-    // Embeds StyleClassedTextArea  2
+    public static StyleClassedTextArea styleClassedTextArea() {
+        return new StyleClassedTextArea();
+    }
+
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea() {
         return new VirtualizedScrollPane<>(styleClassedTextArea());
     }
 
-    // Clones StyleClassedTextArea
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedStyleClassedTextArea(Consumer<StyleClassedTextArea> modifier) {
+        StyleClassedTextArea area = styleClassedTextArea();
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
+    }
+
     public static StyleClassedTextArea cloneStyleClassedTextArea(StyleClassedTextArea area) {
         return new StyleClassedTextArea(area.getContent(), area.isPreserveStyle());
     }
 
-    // Embeds cloned StyleClassedTextArea
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(StyleClassedTextArea area) {
         return new VirtualizedScrollPane<>(cloneStyleClassedTextArea(area));
     }
 
-    // Embeds a cloned StyleClassedTextArea from an embedded StyleClassedTextArea
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(
+            StyleClassedTextArea area, Consumer<StyleClassedTextArea> modifier) {
+        StyleClassedTextArea clone = cloneStyleClassedTextArea(area);
+        modifier.accept(clone);
+        return new VirtualizedScrollPane<>(clone);
+    }
+
     public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(
             VirtualizedScrollPane<StyleClassedTextArea> virtualizedScrollPaneWithArea
     ) {
         return embeddedClonedStyleClassedTextArea(virtualizedScrollPaneWithArea.getContent());
+    }
+
+    public static VirtualizedScrollPane<StyleClassedTextArea> embeddedClonedStyleClassedTextArea(
+            VirtualizedScrollPane<StyleClassedTextArea> virtualizedScrollPaneWithArea,
+            Consumer<StyleClassedTextArea> modifier
+    ) {
+        return embeddedClonedStyleClassedTextArea(virtualizedScrollPaneWithArea.getContent(), modifier);
     }
 
     /* ********************************************************************** *
@@ -126,39 +180,56 @@ public class AreaFactory {
      *                                                                        *
      * ********************************************************************** */
 
-    // CodeArea 1
     public static CodeArea codeArea() {
         return new CodeArea();
     }
 
-    // Embeds CodeArea 1
     public static VirtualizedScrollPane<CodeArea> embeddedCodeArea() {
         return new VirtualizedScrollPane<>(codeArea());
     }
 
-    // CodeArea 2
+    public static VirtualizedScrollPane<CodeArea> embeddedCodeArea(Consumer<CodeArea> modifier) {
+        CodeArea area = codeArea();
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
+    }
+
     public static CodeArea codeArea(String text) {
         return new CodeArea(text);
     }
 
-    // Embeds CodeArea 2
     public static VirtualizedScrollPane<CodeArea> embeddedCodeArea(String text) {
         return new VirtualizedScrollPane<>(codeArea(text));
     }
 
-    // Clones CodeArea
+    public static VirtualizedScrollPane<CodeArea> embeddedCodeArea(String text, Consumer<CodeArea> modifier) {
+        CodeArea area = codeArea(text);
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
+    }
+
     public static CodeArea cloneCodeArea(CodeArea area) {
         return new CodeArea(area.getContent());
     }
 
-    // Embeds a cloned CodeArea
     public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(CodeArea area) {
         return new VirtualizedScrollPane<>(cloneCodeArea(area));
     }
 
-    // Embeds a cloned CodeArea from an embedded CodeArea
-    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(VirtualizedScrollPane<CodeArea> virtualizedScrollPaneWithArea) {
-        return new VirtualizedScrollPane<>(cloneCodeArea(virtualizedScrollPaneWithArea.getContent()));
+    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(CodeArea area, Consumer<CodeArea> modifier) {
+        CodeArea clone = cloneCodeArea(area);
+        modifier.accept(clone);
+        return new VirtualizedScrollPane<>(clone);
+    }
+
+    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(
+            VirtualizedScrollPane<CodeArea> virtualizedScrollPaneWithArea) {
+        return embeddedClonedCodeArea(virtualizedScrollPaneWithArea.getContent());
+    }
+
+    public static VirtualizedScrollPane<CodeArea> embeddedClonedCodeArea(
+            VirtualizedScrollPane<CodeArea> virtualizedScrollPaneWithArea, Consumer<CodeArea> modifier) {
+        return embeddedClonedCodeArea(virtualizedScrollPaneWithArea.getContent(), modifier);
     }
 
     /* ********************************************************************** *
@@ -167,40 +238,58 @@ public class AreaFactory {
      *                                                                        *
      * ********************************************************************** */
 
-    // InlineCssTextArea 1
     public static InlineCssTextArea inlineCssTextArea() {
         return new InlineCssTextArea();
     }
 
-    // Embeds InlineCssTextArea 1
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea() {
         return new VirtualizedScrollPane<>(inlineCssTextArea());
     }
 
-    // InlineCssTextArea 2
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea(Consumer<InlineCssTextArea> modifier) {
+        InlineCssTextArea area = inlineCssTextArea();
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
+    }
+
     public static InlineCssTextArea inlineCssTextArea(String text) {
         return new InlineCssTextArea(text);
     }
 
-    // Embeds InlineCssTextArea 2
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea(String text) {
         return new VirtualizedScrollPane<>(inlineCssTextArea(text));
     }
 
-    // Clones InlineCssTextArea
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedInlineCssTextArea(String text, Consumer<InlineCssTextArea> modifier) {
+        InlineCssTextArea area = inlineCssTextArea(text);
+        modifier.accept(area);
+        return new VirtualizedScrollPane<>(area);
+    }
+
     public static InlineCssTextArea cloneInlineCssTextArea(InlineCssTextArea area) {
         return new InlineCssTextArea(area.getContent());
     }
 
-    // Embeds a cloned InlineCssTextArea
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(InlineCssTextArea area) {
         return new VirtualizedScrollPane<>(cloneInlineCssTextArea(area));
     }
 
-    // Embeds a cloned InlineCssTextArea from an embedded InlineCssTextArea
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(InlineCssTextArea area, Consumer<InlineCssTextArea> modifier) {
+        InlineCssTextArea clone = cloneInlineCssTextArea(area);
+        modifier.accept(clone);
+        return new VirtualizedScrollPane<>(cloneInlineCssTextArea(area));
+    }
+
     public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(
             VirtualizedScrollPane<InlineCssTextArea> virtualizedScrollPaneWithArea
     ) {
         return new VirtualizedScrollPane<>(cloneInlineCssTextArea(virtualizedScrollPaneWithArea.getContent()));
+    }
+
+    public static VirtualizedScrollPane<InlineCssTextArea> embeddedClonedInlineCssTextArea(
+            VirtualizedScrollPane<InlineCssTextArea> virtualizedScrollPaneWithArea,
+            Consumer<InlineCssTextArea> modifier
+    ) {
+        return embeddedClonedInlineCssTextArea(virtualizedScrollPaneWithArea.getContent(), modifier);
     }
 }


### PR DESCRIPTION
AreaFactory did three things:
- convenience methods that embed an area into a VirtualizedScrollPane (basically, gave it scroll bars)
- cloned an area
- due to the above two usages, also provide each area's constructor so that all necessary methods are found in the same class

Unfortunately, the structure prevented subclasses from cloning themselves. Thus, EditableStyledDocument was made public as an interface. Now that cloning is not restricted to AreaFactory (and the constructors were added), it seemed that AreaFactory's constructor methods could be removed and the embedding methods could be moved to their corresponding area's class.

However, this also had its problems.
1. the source code for each of the three flavors (which is relatively small) doubled in size due to the above methods being moved to their location. StyledTextArea, which is already large as it is, would be filled with even more lines.
2. using the same name for all areas (embeddedInstance) led to naming conflicts between StyleClassedTextArea and CodeArea
2. moving the `clone[AreaType]` to each area pollutes subclasses with unnecessary API.

So, the methods will stay where they are but Consumers will allow editing of the constructed area before it is embedded into a VirtualizedScrollPane. Note: sometimes this is helpful (see JavaKeywords demo as an example. Other times it's just easier to write it the normal way: construct an area, modify it, then wrap it in a VirtualizedScrollPane