### PR TITLE
Get exact LinesCount!

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -1229,7 +1229,11 @@ public class StyledTextArea<PS, S> extends Region
         });
     }
 
-    private Optional<Bounds> getCaretBoundsOnScreen() {
+    public int getParagraphLinesCount(int index){
+        return virtualFlow.getCell(index).getNode().getLineCount();
+    }
+
+    public Optional<Bounds> getCaretBoundsOnScreen() {
         return virtualFlow.getCellIfVisible(getCurrentParagraph())
                 .map(c -> c.getNode().getCaretBoundsOnScreen());
     }


### PR DESCRIPTION
- new method **getParagraphLinesCount**, returns an integer of linesCount in a specific Paragraph using its index as parameter.  
- **getCaretBoundsOnScreen** method in class StyledTextArea is now public, used to determine if the caret is outside the screen or not.
