### PR TITLE
Prevent unneeded emission by filtering out negative values

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -249,6 +249,7 @@ class StyledTextAreaBehavior {
                 projection,
                 Point2D::subtract);
         EventStream<Point2D> deltas = nonNullValuesOf(distance)
+                .filter(dist -> dist.getX() >= 0 && dist.getY() >= 0)
                 .emitBothOnEach(animationFrames())
                 .map(t -> t.map((ds, nanos) -> ds.multiply(nanos / 100_000_000.0)));
         valuesOf(autoscrollTo).flatMap(p -> p == null


### PR DESCRIPTION
This fixes #357. `emitBothOnEach` would continuously fire due to `distance` having a negative X value in @MichelMunoz's gif example. Since the point of origin is the top-left corner of the area, any negative values can be excluded. Once this is done, the `emitBothOnEach` EventStream, which only emits an event when both `animationFrames()` and `distance` emit a new event, only emits a new event when `distance` emits a non-negative x/y point. 