### PR TITLE
Include UndoManager in StyledTextArea's constructor's parameter list …

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
@@ -4,6 +4,7 @@ package org.fxmisc.richtext;
 import java.util.Collection;
 
 import org.fxmisc.richtext.model.EditableStyledDocument;
+import org.fxmisc.undo.UndoManager;
 
 /**
  * A convenience subclass of {@link StyleClassedTextArea}
@@ -24,6 +25,10 @@ public class CodeArea extends StyleClassedTextArea {
 
     public CodeArea(EditableStyledDocument<Collection<String>, Collection<String>> document) {
         super(document, false);
+    }
+
+    public CodeArea(EditableStyledDocument<Collection<String>, Collection<String>> document, UndoManager undoManager) {
+        super(document, false, undoManager);
     }
 
     public CodeArea() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
@@ -6,6 +6,7 @@ import org.fxmisc.richtext.model.EditableStyledDocument;
 import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
 
 import javafx.scene.text.TextFlow;
+import org.fxmisc.undo.UndoManager;
 
 /**
  * Text area that uses inline css to define style of text segments and paragraph segments.
@@ -17,11 +18,15 @@ public class InlineCssTextArea extends StyledTextArea<String, String> {
     }
 
     public InlineCssTextArea(EditableStyledDocument<String, String> document) {
+        this(document, null);
+    }
+
+    public InlineCssTextArea(EditableStyledDocument<String, String> document, UndoManager undoManager) {
         super(
                 "", TextFlow::setStyle,
                 "", TextExt::setStyle,
                 document,
-                true
+                true, undoManager
         );
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import org.fxmisc.richtext.model.Codec;
 import org.fxmisc.richtext.model.EditableStyledDocument;
 import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
+import org.fxmisc.undo.UndoManager;
 
 /**
  * Text area that uses style classes to define style of text segments and paragraph segments.
@@ -13,11 +14,17 @@ import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
 public class StyleClassedTextArea extends StyledTextArea<Collection<String>, Collection<String>> {
 
     public StyleClassedTextArea(EditableStyledDocument<Collection<String>, Collection<String>> document, boolean preserveStyle) {
+        this(document, preserveStyle, null);
+    }
+
+    public StyleClassedTextArea(EditableStyledDocument<Collection<String>, Collection<String>> document, boolean preserveStyle,
+                                UndoManager undoManager
+    ) {
         super(Collections.<String>emptyList(),
                 (paragraph, styleClasses) -> paragraph.getStyleClass().addAll(styleClasses),
                 Collections.<String>emptyList(),
                 (text, styleClasses) -> text.getStyleClass().addAll(styleClasses),
-                document, preserveStyle
+                document, preserveStyle, undoManager
         );
 
         setStyleCodecs(

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -8,7 +8,6 @@ import static org.reactfx.util.Tuples.*;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
@@ -1163,30 +1162,30 @@ public class StyledTextArea<PS, S> extends Region
         virtualFlow.dispose();
     }
 
-    public UndoManager createPlainLinearUndoManager(UndoManagerFactory factory) {
-        return model.createPlainLinearUndoManager(factory);
+    public UndoManager createPlainUndoManager(UndoManagerFactory<PlainTextChange> factory, int capacity) {
+        return model.createPlainUndoManager(factory, capacity);
     }
 
     /**
      * Convenience method that removes the area's previous {@link UndoManager} and sets one that handles
      * plain text changes. <em>Note: any previous undo manager undo/redo history will be lost!</em> See
-     * {@link #installNewRichLinearUndoManager(UndoManagerFactory)}} for rich text undo manager.
+     * {@link #installNewRichUndoManager(UndoManagerFactory, int)}} for rich text undo manager.
      */
-    public void installNewPlainLinearUndoManager(UndoManagerFactory factory) {
-        setUndoManager(createPlainLinearUndoManager(factory));
+    public void installNewPlainUndoManager(UndoManagerFactory<PlainTextChange> factory, int capacity) {
+        setUndoManager(createPlainUndoManager(factory, capacity));
     }
 
-    public UndoManager createRichLinearUndoManager(UndoManagerFactory factory) {
-        return model.createRichLinearUndoManager(factory);
+    public UndoManager createRichUndoManager(UndoManagerFactory<RichTextChange<PS, S>> factory, int capacity) {
+        return model.createRichUndoManager(factory, capacity);
     }
 
     /**
      * Convenience method that removes the area's previous {@link UndoManager} and sets one that handles
      * rich text changes. <em>Note: any previous undo manager undo/redo history will be lost!</em> See
-     * {@link #installNewPlainLinearUndoManager(UndoManagerFactory)}} for plain text undo manager
+     * {@link #installNewPlainUndoManager(UndoManagerFactory, int)} for plain text undo manager
      */
-    public void installNewRichLinearUndoManager(UndoManagerFactory factory) {
-        setUndoManager(createRichLinearUndoManager(factory));
+    public void installNewRichUndoManager(UndoManagerFactory<RichTextChange<PS, S>> factory, int capacity) {
+        setUndoManager(createRichUndoManager(factory, capacity));
     }
 
     /* ********************************************************************** *

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/UndoActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/UndoActions.java
@@ -3,7 +3,6 @@ package org.fxmisc.richtext.model;
 import javafx.beans.value.ObservableBooleanValue;
 
 import org.fxmisc.undo.UndoManager;
-import org.fxmisc.undo.UndoManagerFactory;
 
 /**
  * Undo/redo actions for {@link TextEditingArea}.
@@ -14,7 +13,8 @@ public interface UndoActions {
      * Undo manager of this text area.
      */
     UndoManager getUndoManager();
-    void setUndoManager(UndoManagerFactory undoManagerFactory);
+
+    void setUndoManager(UndoManager undoManager);
 
     default void undo() { getUndoManager().undo(); }
 


### PR DESCRIPTION
…in preparation for NonlinearUndoManagers
- Source compatibility is maintained
- Since `setUndoManager(UndoManagerFactory)` was removed, the API necessary for adding an UndoManager with alternative history sizes (i.e. fixed size or zero size) was moved from STAModel to STA. Additionally, two convenience methods were added to make installing them just as convenient: `installNew[Plain/Rich]LinearUndoManager(UndoManagerFactory)`.

This addresses #333. Since my PR for nonlinear undos/redos on UndoFX is complicated, this commit would allow me to test it using RichTextFX and a local compiled copy of UndoFX with my commits.
