### PR TITLE
Fix computing hit character if padding is set on the paragraph-text

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -134,7 +134,8 @@ class ParagraphBox<PS, S> extends Region {
     public CharacterHit hit(double x, double y) {
         Point2D onScreen = this.localToScreen(x, y);
         Point2D inText = text.screenToLocal(onScreen);
-        return text.hit(inText.getX(), inText.getY());
+        Insets textInsets = text.getInsets();
+        return text.hit(inText.getX() - textInsets.getLeft(), inText.getY() - textInsets.getTop());
     }
 
     public CaretOffsetX getCaretOffsetX() {


### PR DESCRIPTION
This PR fixes computing hit character (at mouse press) if padding is set on the paragraph-text.

To reproduce this, apply a large padding (as below), click at some text in the styled text area and see where the caret is positioned. Without this fix the caret is always some characters right to the click location.

```
.styled-text-area .paragraph-box .paragraph-text {
    -fx-padding: 0 10em 0 10em;
}
.styled-text-area .paragraph-box:first-paragraph .paragraph-text {
    -fx-padding: 10em 10em 0 10em;
}
.styled-text-area .paragraph-box:last-paragraph .paragraph-text {
    -fx-padding: 0 10em 10em 10em;
}
```