### PR TITLE
Added background color to spell checker demo. Fixed order of shapes s…

### DIFF
--- a/richtextfx-demos/src/main/resources/org/fxmisc/richtext/demo/spellchecking.css
+++ b/richtextfx-demos/src/main/resources/org/fxmisc/richtext/demo/spellchecking.css
@@ -1,4 +1,5 @@
 .underlined {
+    -rtfx-background-color: #f0f0f0;
     -rtfx-underline-color: red;
     -rtfx-underline-dash-array: 2 2;
     -rtfx-underline-width: 1;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -127,7 +127,7 @@ class ParagraphText<PS, S> extends TextFlowExt {
             underlineShape.layoutXProperty().bind(leftInset);
             underlineShape.layoutYProperty().bind(topInset);
             underlineShapes.add(underlineShape);
-            getChildren().add(0, underlineShape);
+            getChildren().add(underlineShape);
         }
     }
 


### PR DESCRIPTION
Fix for issue #407: 
Added background color to spell checker demo.
Fixed order of shapes so that underlines are shown even if a background shape is used.