### PR TITLE
Deprecate Popup API; add caret/selection bounds properties

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/PopupDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/PopupDemo.java
@@ -1,48 +1,186 @@
 package org.fxmisc.richtext.demo;
 
 import javafx.application.Application;
-import javafx.geometry.Point2D;
+import javafx.geometry.Bounds;
+import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.layout.Priority;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.stage.Popup;
 import javafx.stage.Stage;
 
+import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.InlineCssTextArea;
-import org.fxmisc.richtext.PopupAlignment;
+import org.reactfx.EventStream;
+import org.reactfx.EventStreams;
+import org.reactfx.Subscription;
+import org.reactfx.value.Var;
+
+import java.util.Optional;
+
+import static org.reactfx.EventStreams.nonNullValuesOf;
 
 public class PopupDemo extends Application {
 
-    public static void main(String[] args) {
-        launch(args);
+    private Stage stage;
+
+    /** Helper class: Popup that can track when it should temporarily hide itself if its object is outside of the
+     * viewport and provides convenience to adding content to both caret/selection popup */
+    private class BoundsPopup extends Popup {
+
+        /** Indicates whether popup should still be shown even when its item (caret/selection) is outside viewport */
+        private final Var<Boolean> showWhenItemOutsideViewport = Var.newSimpleVar(true);
+        public final EventStream<Boolean> outsideViewportValues() { return showWhenItemOutsideViewport.values(); }
+        public final void invertViewportOption() {
+            showWhenItemOutsideViewport.setValue(!showWhenItemOutsideViewport.getValue());
+        }
+
+        /** Indicates whether popup has been hidden since its item (caret/selection) is outside viewport
+         * and should be shown when that item becomes visible again */
+        private final Var<Boolean> hideTemporarily = Var.newSimpleVar(false);
+        public final boolean isHiddenTemporarily() { return hideTemporarily.getValue(); }
+        public final void setHideTemporarily(boolean value) { hideTemporarily.setValue(value); }
+
+        public final void invertVisibility() {
+            if (isShowing()) {
+                hide();
+            } else {
+                show(stage);
+            }
+        }
+
+        private final VBox vbox;
+        private final Button button;
+
+        private final Label label;
+        public final void setText(String text) { label.setText(text); }
+
+        BoundsPopup(String buttonText) {
+            super();
+            button = new Button(buttonText);
+            label = new Label();
+            vbox = new VBox(button, label);
+            vbox.setBackground(new Background(new BackgroundFill(Color.ALICEBLUE, null, null)));
+            vbox.setPadding(new Insets(5));
+            getContent().add(vbox);
+        }
+    }
+
+    private VBox createPopupOptions(BoundsPopup p, String showHideButtonText, String toggleViewportText) {
+        Button showOrHidePopup = new Button(showHideButtonText);
+        showOrHidePopup.setOnAction(ae -> p.invertVisibility());
+        Button toggleOutOfViewportOption = new Button(toggleViewportText);
+        toggleOutOfViewportOption.setOnAction(ae -> p.invertViewportOption());
+        return new VBox(showOrHidePopup, toggleOutOfViewportOption);
+    }
+
+    private Subscription feedVisibilityToLabelText(EventStream<Optional<Bounds>> boundsStream, BoundsPopup popup, String item) {
+        return boundsStream
+                .map(o -> o.isPresent() ? " is " : " is not ")
+                .subscribe(visibilityStatus -> popup.setText(item + visibilityStatus + "within the viewport"));
     }
 
     @Override
     public void start(Stage primaryStage) {
-        InlineCssTextArea area = new InlineCssTextArea("Hello popup!");
+        stage = primaryStage;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 2; i < 100; i++) {
+            sb.append(String.valueOf(i)).append("        END\n");
+        }
+        InlineCssTextArea area = new InlineCssTextArea("Hello popup!\n" + sb.toString());
         area.setWrapText(true);
+        VirtualizedScrollPane<InlineCssTextArea> vsPane = new VirtualizedScrollPane<>(area);
 
-        Popup popup = new Popup();
-        popup.getContent().add(new Button("I am a popup button!"));
-        area.setPopupWindow(popup);
-        area.setPopupAlignment(PopupAlignment.SELECTION_BOTTOM_CENTER);
-        area.setPopupAnchorOffset(new Point2D(4, 4));
+        BoundsPopup caretPopup = new BoundsPopup("I am the caret popup button!");
+        BoundsPopup selectionPopup = new BoundsPopup("I am the selection popup button!");
 
-        Button toggle = new Button("Show/Hide popup");
-        toggle.setOnAction(ae -> {
-            if(popup.isShowing()) {
-                popup.hide();
-            } else {
-                popup.show(primaryStage);
-            }
-        });
+        VBox caretOptions = createPopupOptions(caretPopup, "Show/Hide caret-based popup", "Show/Hide popup even when caret is out of viewport");
+        VBox selectionOptions = createPopupOptions(selectionPopup, "Show/Hide selection-based popup", "Show/Hide popup even when selection is out of viewport");
 
-        VBox.setVgrow(area, Priority.ALWAYS);
+        BorderPane borderPane = new BorderPane();
+        borderPane.setTop(caretOptions);
+        borderPane.setCenter(vsPane);
+        borderPane.setBottom(selectionOptions);
 
-        primaryStage.setScene(new Scene(new VBox(toggle, area), 200, 200));
+        primaryStage.setScene(new Scene(borderPane, 400, 500));
         primaryStage.setTitle("Popup Demo");
         primaryStage.show();
-        popup.show(primaryStage);
+
+        // ### Set up EventStreams
+        // update labels depending on whether item is within viewport
+        EventStream<Optional<Bounds>> caretBounds = nonNullValuesOf(area.caretBoundsProperty());
+        Subscription cBoundsSub = feedVisibilityToLabelText(caretBounds, caretPopup, "Caret");
+        EventStream<Optional<Bounds>> selectionBounds = nonNullValuesOf(area.selectionBoundsProperty());
+        Subscription sBoundsSub = feedVisibilityToLabelText(selectionBounds, selectionPopup, "Selection");
+
+        // set up event streams to update popups every time bounds change
+        double caretXOffset = 0;
+        double caretYOffset = 0;
+        double selectionXOffset = 30;
+        double selectionYOffset = 30;
+
+        Subscription caretPopupSub = EventStreams.combine(caretBounds, caretPopup.outsideViewportValues())
+                .subscribe(tuple3 -> {
+                    Optional<Bounds> opt = tuple3._1;
+                    boolean showPopupWhenCaretOutside = tuple3._2;
+
+                    if (opt.isPresent()) {
+                        Bounds b = opt.get();
+                        caretPopup.setX(b.getMaxX() + caretXOffset);
+                        caretPopup.setY(b.getMaxY() + caretYOffset);
+
+                        if (caretPopup.isHiddenTemporarily()) {
+                            caretPopup.show(stage);
+                            caretPopup.setHideTemporarily(false);
+                        }
+
+                    } else {
+                        if (!showPopupWhenCaretOutside) {
+                            caretPopup.hide();
+                            caretPopup.setHideTemporarily(true);
+                        }
+                    }
+                });
+
+        Subscription selectionPopupSub = EventStreams.combine(selectionBounds, selectionPopup.outsideViewportValues())
+                .subscribe(tuple3 -> {
+                    Optional<Bounds> opt = tuple3._1;
+                    boolean showPopupWhenSelectionOutside = tuple3._2;
+
+                    if (opt.isPresent()) {
+                        Bounds b = opt.get();
+                        selectionPopup.setX(b.getMinX() + selectionXOffset + caretPopup.getWidth());
+                        selectionPopup.setY(b.getMinY() + selectionYOffset);
+
+                        if (selectionPopup.isHiddenTemporarily()) {
+                            selectionPopup.show(stage);
+                            selectionPopup.setHideTemporarily(false);
+                        }
+
+                    } else {
+                        if (!showPopupWhenSelectionOutside) {
+                            selectionPopup.hide();
+                            selectionPopup.setHideTemporarily(true);
+                        }
+                    }
+                });
+
+        Subscription caretSubs      = caretPopupSub.and(cBoundsSub);
+        Subscription selectionSubs  = selectionPopupSub.and(sBoundsSub);
+
+        caretPopup.show(primaryStage);
+        selectionPopup.show(primaryStage);
+        area.moveTo(0);
+        area.requestFollowCaret();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -74,8 +74,10 @@ import org.fxmisc.undo.UndoManager;
 import org.fxmisc.undo.UndoManagerFactory;
 import org.reactfx.EventStream;
 import org.reactfx.EventStreams;
+import org.reactfx.Guard;
 import org.reactfx.StateMachine;
 import org.reactfx.Subscription;
+import org.reactfx.SuspendableEventStream;
 import org.reactfx.collection.LiveList;
 import org.reactfx.util.Tuple2;
 import org.reactfx.value.Val;
@@ -245,19 +247,47 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      * how the popup should be positioned relative to the caret or selection.
      * Use {@link #popupAnchorOffsetProperty()} or
      * {@link #popupAnchorAdjustmentProperty()} to further adjust the position.
+     *
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
      */
+    @Deprecated
     private final ObjectProperty<PopupWindow> popupWindow = new SimpleObjectProperty<>();
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public void setPopupWindow(PopupWindow popup) { popupWindow.set(popup); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public PopupWindow getPopupWindow() { return popupWindow.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public ObjectProperty<PopupWindow> popupWindowProperty() { return popupWindow; }
 
-    /** @deprecated Use {@link #setPopupWindow(PopupWindow)}. */
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
     @Deprecated
     public void setPopupAtCaret(PopupWindow popup) { popupWindow.set(popup); }
-    /** @deprecated Use {@link #getPopupWindow()}. */
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
     @Deprecated
     public PopupWindow getPopupAtCaret() { return popupWindow.get(); }
-    /** @deprecated Use {@link #popupWindowProperty()}. */
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
     @Deprecated
     public ObjectProperty<PopupWindow> popupAtCaretProperty() { return popupWindow; }
 
@@ -267,10 +297,29 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      *
      * <p>If {@link #popupAnchorAdjustmentProperty()} is also specified, then
      * it overrides the offset set by this property.
+     *
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
      */
+    @Deprecated
     private final ObjectProperty<Point2D> popupAnchorOffset = new SimpleObjectProperty<>();
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public void setPopupAnchorOffset(Point2D offset) { popupAnchorOffset.set(offset); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public Point2D getPopupAnchorOffset() { return popupAnchorOffset.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public ObjectProperty<Point2D> popupAnchorOffsetProperty() { return popupAnchorOffset; }
 
     /**
@@ -281,9 +330,25 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      *
      * <p>Setting this property overrides {@link #popupAnchorOffsetProperty()}.
      */
+    @Deprecated
     private final ObjectProperty<UnaryOperator<Point2D>> popupAnchorAdjustment = new SimpleObjectProperty<>();
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public void setPopupAnchorAdjustment(UnaryOperator<Point2D> f) { popupAnchorAdjustment.set(f); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public UnaryOperator<Point2D> getPopupAnchorAdjustment() { return popupAnchorAdjustment.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public ObjectProperty<UnaryOperator<Point2D>> popupAnchorAdjustmentProperty() { return popupAnchorAdjustment; }
 
     /**
@@ -291,10 +356,29 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      * is anchored, i.e. where its anchor point is positioned. This position
      * can further be adjusted by {@link #popupAnchorOffsetProperty()} or
      * {@link #popupAnchorAdjustmentProperty()}.
+     *
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
      */
+    @Deprecated
     private final ObjectProperty<PopupAlignment> popupAlignment = new SimpleObjectProperty<>(CARET_TOP);
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public void setPopupAlignment(PopupAlignment pos) { popupAlignment.set(pos); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public PopupAlignment getPopupAlignment() { return popupAlignment.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
     public ObjectProperty<PopupAlignment> popupAlignmentProperty() { return popupAlignment; }
 
     /**
@@ -395,6 +479,15 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public final int getCaretPosition() { return model.getCaretPosition(); }
     @Override public final ObservableValue<Integer> caretPositionProperty() { return model.caretPositionProperty(); }
 
+    // caret bounds
+    /**
+     * The bounds of the caret in the Screen's coordinate system or {@link Optional#empty()} if caret is not visible
+     * in the viewport.
+     */
+    private final Val<Optional<Bounds>> caretBounds;
+    public final Optional<Bounds> getCaretBounds() { return caretBounds.getValue(); }
+    public final ObservableValue<Optional<Bounds>> caretBoundsProperty() { return caretBounds; }
+
     // selection anchor
     @Override public final int getAnchor() { return model.getAnchor(); }
     @Override public final ObservableValue<Integer> anchorProperty() { return model.anchorProperty(); }
@@ -406,6 +499,16 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     // selected text
     @Override public final String getSelectedText() { return model.getSelectedText(); }
     @Override public final ObservableValue<String> selectedTextProperty() { return model.selectedTextProperty(); }
+
+    // selection bounds
+    /**
+     * The bounds of the selection in the Screen's coordinate system if something is selected and visible in the
+     * viewport, {@link #caretBounds} if nothing is selected and caret is visible in the viewport, or
+     * {@link Optional#empty()} if selection is not visible in the viewport.
+     */
+    private final Val<Optional<Bounds>> selectionBounds;
+    public final Optional<Bounds> getSelectionBounds() { return selectionBounds.getValue(); }
+    public final ObservableValue<Optional<Bounds>> selectionBoundsProperty() { return selectionBounds; }
 
     // current paragraph index
     @Override public final int getCurrentParagraph() { return model.getCurrentParagraph(); }
@@ -476,6 +579,8 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     private final TwoLevelNavigator navigator;
 
     private boolean followCaretRequested = false;
+
+    private final SuspendableEventStream<?> viewportDirty;
 
     /**
      * model
@@ -673,6 +778,26 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 .toBinding(false);
         manageBinding(caretVisible);
 
+        viewportDirty = merge(
+                // no need to check for width & height invalidations as scroll values update when these do
+
+                // scale
+                invalidationsOf(scaleXProperty()),
+                invalidationsOf(scaleYProperty()),
+
+                // scroll
+                invalidationsOf(estimatedScrollXProperty()),
+                invalidationsOf(estimatedScrollYProperty())
+        ).suppressible();
+        EventStream<?> caretBoundsDirty = merge(viewportDirty, caretDirty)
+                .suppressWhen(model.beingUpdatedProperty());
+        EventStream<?> selectionBoundsDirty = merge(viewportDirty, invalidationsOf(selectionProperty()))
+                .suppressWhen(model.beingUpdatedProperty());
+
+        // updates the bounds of the caret/selection
+        caretBounds = Val.create(this::getCaretBoundsOnScreen, caretBoundsDirty);
+        selectionBounds = Val.create(this::impl_bounds_getSelectionBoundsOnScreen, selectionBoundsDirty);
+
         // Adjust popup anchor by either a user-provided function,
         // or user-provided offset, or don't adjust at all.
         Val<UnaryOperator<Point2D>> userOffset = Val.map(
@@ -707,7 +832,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      * Returns caret bounds relative to the viewport, i.e. the visual bounds
      * of the embedded VirtualFlow.
      */
-    Optional<Bounds> getCaretBounds() {
+    Optional<Bounds> getCaretBoundsInViewport() {
         return virtualFlow.getCellIfVisible(getCurrentParagraph())
                 .map(c -> {
                     Bounds cellBounds = c.getNode().getCaretBounds();
@@ -1217,7 +1342,9 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         virtualFlow.resize(getWidth(), getHeight());
         if(followCaretRequested) {
             followCaretRequested = false;
-            followCaret();
+            try (Guard g = viewportDirty.suspend()) {
+                followCaret();
+            }
         }
 
         // position popup
@@ -1340,7 +1467,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         Optional<Bounds> bounds = null;
         switch(alignment.getAnchorObject()) {
             case CARET: bounds = getCaretBoundsOnScreen(); break;
-            case SELECTION: bounds = getSelectionBoundsOnScreen(); break;
+            case SELECTION: bounds = impl_popup_getSelectionBoundsOnScreen(); break;
         }
         bounds.ifPresent(b -> {
             double x = 0, y = 0;
@@ -1365,12 +1492,24 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 .map(c -> c.getNode().getCaretBoundsOnScreen());
     }
 
-    private Optional<Bounds> getSelectionBoundsOnScreen() {
+    private Optional<Bounds> impl_popup_getSelectionBoundsOnScreen() {
         IndexRange selection = getSelection();
         if(selection.getLength() == 0) {
             return getCaretBoundsOnScreen();
         }
 
+        return impl_getSelectionBoundsOnScreen();
+    }
+
+    private Optional<Bounds> impl_bounds_getSelectionBoundsOnScreen() {
+        IndexRange selection = getSelection();
+        if (selection.getLength() == 0) {
+            return Optional.empty();
+        }
+        return impl_getSelectionBoundsOnScreen();
+    }
+
+    private Optional<Bounds> impl_getSelectionBoundsOnScreen() {
         Bounds[] bounds = virtualFlow.visibleCells().stream()
                 .map(c -> c.getNode().getSelectionBoundsOnScreen())
                 .filter(Optional::isPresent)

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -242,146 +242,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     }
 
     /**
-     * Popup window that will be positioned by this text area relative to the
-     * caret or selection. Use {@link #popupAlignmentProperty()} to specify
-     * how the popup should be positioned relative to the caret or selection.
-     * Use {@link #popupAnchorOffsetProperty()} or
-     * {@link #popupAnchorAdjustmentProperty()} to further adjust the position.
-     *
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    private final ObjectProperty<PopupWindow> popupWindow = new SimpleObjectProperty<>();
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public void setPopupWindow(PopupWindow popup) { popupWindow.set(popup); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public PopupWindow getPopupWindow() { return popupWindow.get(); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public ObjectProperty<PopupWindow> popupWindowProperty() { return popupWindow; }
-
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public void setPopupAtCaret(PopupWindow popup) { popupWindow.set(popup); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public PopupWindow getPopupAtCaret() { return popupWindow.get(); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public ObjectProperty<PopupWindow> popupAtCaretProperty() { return popupWindow; }
-
-    /**
-     * Specifies further offset (in pixels) of the popup window from the
-     * position specified by {@link #popupAlignmentProperty()}.
-     *
-     * <p>If {@link #popupAnchorAdjustmentProperty()} is also specified, then
-     * it overrides the offset set by this property.
-     *
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    private final ObjectProperty<Point2D> popupAnchorOffset = new SimpleObjectProperty<>();
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public void setPopupAnchorOffset(Point2D offset) { popupAnchorOffset.set(offset); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public Point2D getPopupAnchorOffset() { return popupAnchorOffset.get(); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public ObjectProperty<Point2D> popupAnchorOffsetProperty() { return popupAnchorOffset; }
-
-    /**
-     * Specifies how to adjust the popup window's anchor point. The given
-     * operator is invoked with the screen position calculated according to
-     * {@link #popupAlignmentProperty()} and should return a new screen
-     * position. This position will be used as the popup window's anchor point.
-     *
-     * <p>Setting this property overrides {@link #popupAnchorOffsetProperty()}.
-     */
-    @Deprecated
-    private final ObjectProperty<UnaryOperator<Point2D>> popupAnchorAdjustment = new SimpleObjectProperty<>();
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public void setPopupAnchorAdjustment(UnaryOperator<Point2D> f) { popupAnchorAdjustment.set(f); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public UnaryOperator<Point2D> getPopupAnchorAdjustment() { return popupAnchorAdjustment.get(); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public ObjectProperty<UnaryOperator<Point2D>> popupAnchorAdjustmentProperty() { return popupAnchorAdjustment; }
-
-    /**
-     * Defines where the popup window given in {@link #popupWindowProperty()}
-     * is anchored, i.e. where its anchor point is positioned. This position
-     * can further be adjusted by {@link #popupAnchorOffsetProperty()} or
-     * {@link #popupAnchorAdjustmentProperty()}.
-     *
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    private final ObjectProperty<PopupAlignment> popupAlignment = new SimpleObjectProperty<>(CARET_TOP);
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public void setPopupAlignment(PopupAlignment pos) { popupAlignment.set(pos); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public PopupAlignment getPopupAlignment() { return popupAlignment.get(); }
-    /**
-     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
-     * {@link #selectionBoundsProperty()} instead.
-     */
-    @Deprecated
-    public ObjectProperty<PopupAlignment> popupAlignmentProperty() { return popupAlignment; }
-
-    /**
      * Defines how long the mouse has to stay still over the text before a
      * {@link MouseOverTextEvent} of type {@code MOUSE_OVER_TEXT_BEGIN} is
      * fired on this text area. When set to {@code null}, no
@@ -1566,4 +1426,154 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 .on(ticks).transition((state, tick) -> !state)
                 .toStateStream();
     }
+
+    /* ********************************************************************** *
+     *                                                                        *
+     * Deprecated Popup API  (Originally a part of "Properties" section       *
+     *                                                                        *
+     * Code was moved to bottom of this file to make it easier to stay        *
+     * focused on code still in use. This whole section should be deleted     *
+     * at a later time.                                                       *
+     *                                                                        *
+     * ********************************************************************** */
+
+    /**
+     * Popup window that will be positioned by this text area relative to the
+     * caret or selection. Use {@link #popupAlignmentProperty()} to specify
+     * how the popup should be positioned relative to the caret or selection.
+     * Use {@link #popupAnchorOffsetProperty()} or
+     * {@link #popupAnchorAdjustmentProperty()} to further adjust the position.
+     *
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    private final ObjectProperty<PopupWindow> popupWindow = new SimpleObjectProperty<>();
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public void setPopupWindow(PopupWindow popup) { popupWindow.set(popup); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public PopupWindow getPopupWindow() { return popupWindow.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public ObjectProperty<PopupWindow> popupWindowProperty() { return popupWindow; }
+
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public void setPopupAtCaret(PopupWindow popup) { popupWindow.set(popup); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public PopupWindow getPopupAtCaret() { return popupWindow.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public ObjectProperty<PopupWindow> popupAtCaretProperty() { return popupWindow; }
+
+    /**
+     * Specifies further offset (in pixels) of the popup window from the
+     * position specified by {@link #popupAlignmentProperty()}.
+     *
+     * <p>If {@link #popupAnchorAdjustmentProperty()} is also specified, then
+     * it overrides the offset set by this property.
+     *
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    private final ObjectProperty<Point2D> popupAnchorOffset = new SimpleObjectProperty<>();
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public void setPopupAnchorOffset(Point2D offset) { popupAnchorOffset.set(offset); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public Point2D getPopupAnchorOffset() { return popupAnchorOffset.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public ObjectProperty<Point2D> popupAnchorOffsetProperty() { return popupAnchorOffset; }
+
+    /**
+     * Specifies how to adjust the popup window's anchor point. The given
+     * operator is invoked with the screen position calculated according to
+     * {@link #popupAlignmentProperty()} and should return a new screen
+     * position. This position will be used as the popup window's anchor point.
+     *
+     * <p>Setting this property overrides {@link #popupAnchorOffsetProperty()}.
+     */
+    @Deprecated
+    private final ObjectProperty<UnaryOperator<Point2D>> popupAnchorAdjustment = new SimpleObjectProperty<>();
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public void setPopupAnchorAdjustment(UnaryOperator<Point2D> f) { popupAnchorAdjustment.set(f); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public UnaryOperator<Point2D> getPopupAnchorAdjustment() { return popupAnchorAdjustment.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public ObjectProperty<UnaryOperator<Point2D>> popupAnchorAdjustmentProperty() { return popupAnchorAdjustment; }
+
+    /**
+     * Defines where the popup window given in {@link #popupWindowProperty()}
+     * is anchored, i.e. where its anchor point is positioned. This position
+     * can further be adjusted by {@link #popupAnchorOffsetProperty()} or
+     * {@link #popupAnchorAdjustmentProperty()}.
+     *
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    private final ObjectProperty<PopupAlignment> popupAlignment = new SimpleObjectProperty<>(CARET_TOP);
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public void setPopupAlignment(PopupAlignment pos) { popupAlignment.set(pos); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public PopupAlignment getPopupAlignment() { return popupAlignment.get(); }
+    /**
+     * @deprecated Use {@link #getCaretBounds()}/{@link #caretBoundsProperty()} or {@link #getSelectionBounds()}/
+     * {@link #selectionBoundsProperty()} instead.
+     */
+    @Deprecated
+    public ObjectProperty<PopupAlignment> popupAlignmentProperty() { return popupAlignment; }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -157,7 +157,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         } else {
             layout(); // ensure layout, is a no-op if not dirty
             Bounds localBounds = selectionShape.getBoundsInLocal();
-            return Optional.of(selectionShape.localToScreen(localBounds));
+            return Optional.ofNullable(selectionShape.localToScreen(localBounds));
         }
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/PopupAlignment.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/PopupAlignment.java
@@ -4,6 +4,8 @@ import static org.fxmisc.richtext.PopupAlignment.HorizontalAlignment.*;
 import static org.fxmisc.richtext.PopupAlignment.AnchorObject.*;
 import static org.fxmisc.richtext.PopupAlignment.VerticalAlignment.*;
 
+/** Deprecated now that caret and selection bounds have an API */
+@Deprecated
 public enum PopupAlignment {
     CARET_TOP(CARET, TOP, H_CENTER),
     CARET_CENTER(CARET, V_CENTER, H_CENTER),


### PR DESCRIPTION
I encountered an issue with calling `getCaretBounds` and `getSelectionBounds` near the same time when using EventStreams.