### PR TITLE
Make `positionCaret` package-private

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1121,17 +1121,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         model.selectRange(anchor, caretPosition);
     }
 
-    /**
-     * {@inheritDoc}
-     * @deprecated You probably meant to use {@link #moveTo(int)}. This method will be made
-     * package-private in the future
-     */
-    @Deprecated
-    @Override
-    public void positionCaret(int pos) {
-        model.positionCaret(pos);
-    }
-
     /* ********************************************************************** *
      *                                                                        *
      * Public API                                                             *
@@ -1242,6 +1231,10 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 cellSelection.dispose();
             }
         };
+    }
+
+    private void positionCaret(int pos) {
+        model.positionCaret(pos);
     }
 
     private ParagraphBox<PS, SEG, S> getCell(int index) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/StyledTextAreaModel.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/StyledTextAreaModel.java
@@ -657,7 +657,12 @@ public class StyledTextAreaModel<PS, SEG, S>
         }
     }
 
-    @Override
+    /**
+     * Positions only the caret. Doesn't move the anchor and doesn't change
+     * the selection. Can be used to achieve the special case of positioning
+     * the caret outside or inside the selection, as opposed to always being
+     * at the boundary. Use with care.
+     */
     public void positionCaret(int pos) {
         try(Guard g = suspend(caretPosition, currentParagraph, caretColumn)) {
             internalCaretPosition.setValue(pos);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/TextEditingArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/TextEditingArea.java
@@ -255,18 +255,6 @@ public interface TextEditingArea<PS, SEG, S> {
     }
 
     /**
-     * Positions only the caret. Doesn't move the anchor and doesn't change
-     * the selection. Can be used to achieve the special case of positioning
-     * the caret outside or inside the selection, as opposed to always being
-     * at the boundary. Use with care.
-     *
-     * @deprecated You probably meant to use {@link NavigationActions#moveTo(int)}. This method will be made
-     *              package-private in the future
-     */
-    @Deprecated
-    public void positionCaret(int pos);
-
-    /**
      * Returns the absolute position (i.e. the spot in-between characters) to the left of the given column in the given paragraph.
      *
      * <p>For example, given a text with only one line {@code "text"} and the columnIndex value of {@code 1}, "position 1" would be returned:</p>


### PR DESCRIPTION
Since this may have value beyond what I know for code editors and the like, I have to ask: why did you originally implement this method? Is making this method package private desirable? AFAIK, we're only doing that because many confused `moveTo`'s functionality for `positionCaret`, since the latter implies that more so than the former.
In my opinion, it would be better to rename `moveTo` to include "caret" in it (`moveCaretTo`? `moveCaret`? `caretTo`?) and rename `positionCaret` to include more explanatory details (`positionCaretDisconnectedly`? `positionCaretSeparately`?).