### PR TITLE
Add API: get the line index of the caret in a multi-line paragraph/viewport

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CaretLineIndexDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/CaretLineIndexDemo.java
@@ -1,0 +1,60 @@
+package org.fxmisc.richtext.demo;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.fxmisc.flowless.VirtualizedScrollPane;
+import org.fxmisc.richtext.InlineCssTextArea;
+import org.fxmisc.richtext.LineNumberFactory;
+import org.reactfx.value.Val;
+
+import java.util.Objects;
+
+public class CaretLineIndexDemo extends Application {
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 15; i++) {  // lines
+            for (int j = 0; j < 100; j++) { // content on each line
+                sb.append(j).append(" ");
+            }
+            sb.append("\n");
+        }
+        InlineCssTextArea area = new InlineCssTextArea(sb.toString());
+        area.setWrapText(true);
+        area.setParagraphGraphicFactory(LineNumberFactory.get(area));
+        VirtualizedScrollPane<InlineCssTextArea> vspane = new VirtualizedScrollPane<>(area);
+
+        Label inParagraphLabel = new Label("");
+        Val.create(area::getCaretLineIndexInParagraph, area.caretPositionProperty())
+                .values()
+                .filter(Objects::nonNull)
+                .map(v -> "Line Index in Paragraph is: " + String.valueOf(v))
+                .feedTo(inParagraphLabel.textProperty());
+
+        Label inViewportLabel = new Label("");
+        Val.create(area::getCaretLineIndexInViewport, area.caretPositionProperty())
+                .values()
+                .filter(Objects::nonNull)
+                .map(v -> "Line Index in Viewport is: " + String.valueOf(v))
+                .feedTo(inViewportLabel.textProperty());
+
+        Label instructions = new Label("Move the caret around with your mouse or keyboard arrows and see the values update.");
+        instructions.setWrapText(true);
+
+        BorderPane root = new BorderPane();
+        root.setTop(instructions);
+        root.setCenter(vspane);
+        root.setBottom(new VBox(inParagraphLabel, inViewportLabel));
+
+        Scene scene = new Scene(root, 500, 500);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+
+        area.moveTo(0);
+        area.requestFollowCaret();
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -806,6 +806,43 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         return virtualFlow.getCell(paragraphIndex).getNode().getLineCount();
     }
 
+    /**
+     * When {@link #isWrapText()} is true and the caret is in a multi-line paragraph, gets the line index within that
+     * paragraph that has the caret, or returns 0.
+     */
+    public int getCaretLineIndexInParagraph() {
+        if (!isWrapText()) {
+            return 0;
+        }
+        return virtualFlow.getCell(getCurrentParagraph()).getNode().getCurrentLineIndex();
+    }
+
+    /**
+     * When {@link #isWrapText()} is true, gets the line index (not paragraph index) that has the caret with
+     * an index of 0 starting at the top of the viewport, or returns -1 if the caret is not currently visible. For
+     * example, if a wrapped area has 5 paragraphs that span 3 lines each and the caret is in the second paragraph's
+     * second line, this method would return 5 (3 lines from the first paragraph + 2 lines from the second paragraph).
+     * <em>Note:</em> this method may return an unexpected value if the first line that the viewport displays is barely
+     * shown.
+     */
+    public int getCaretLineIndexInViewport() {
+        Optional<Cell<Paragraph<PS, SEG, S>, ParagraphBox<PS, SEG, S>>> currentPar = virtualFlow.getCellIfVisible(getCurrentParagraph());
+        if (currentPar.isPresent()) {
+            Cell<Paragraph<PS, SEG, S>, ParagraphBox<PS, SEG, S>> cellWithCaret = currentPar.get();
+            int count = cellWithCaret.getNode().getCurrentLineIndex();
+            for (Cell<Paragraph<PS, SEG, S>, ParagraphBox<PS, SEG, S>> c : virtualFlow.visibleCells()) {
+                if (c == cellWithCaret) {
+                    break;
+                }
+                count += c.getNode().getLineCount();
+            }
+            return count;
+
+        } else {
+            return -1;
+        }
+    }
+
     @Override
     public final String getText(int start, int end) {
         return model.getText(start, end);


### PR DESCRIPTION
Implements feature requested in #386:

> It would be convenient if there was a getLineNumber() method that indicated the line number within the current paragraph, such as:

````java
StyleClassedTextArea editor = // ...
Paragraph p = editor.getCurrentParagraph();
int n = p.getLineNumber();
````

> Asking the editor's line number should give the line number from the top of the text area (starting from line 1), not the current paragraph. Also, using natural numbers seems like a good fit, as opposed to whole numbers, for line numbers.