### PR TITLE
Update method & behavior: lineStart/End, not paragraphStart/End

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1041,6 +1041,36 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     }
 
     /**
+     * Move the caret to the start of either the line in a multi-line wrapped paragraph or the paragraph
+     * in a single-line / non-wrapped paragraph
+     *
+     * @param policy
+     */
+    public void lineStart(SelectionPolicy policy) {
+        int columnPos = virtualFlow.getCell(getCurrentParagraph()).getNode().getCurrentLineStartPosition();
+        moveTo(getCurrentParagraph(), columnPos, policy);
+    }
+
+    /**
+     * Move the caret to the end of either the line in a multi-line wrapped paragraph or the paragraph
+     * in a single-line / non-wrapped paragraph
+     *
+     * @param policy
+     */
+    public void lineEnd(SelectionPolicy policy) {
+        int columnPos = virtualFlow.getCell(getCurrentParagraph()).getNode().getCurrentLineEndPosition();
+        moveTo(getCurrentParagraph(), columnPos, policy);
+    }
+
+    /**
+     * Selects the current line.
+     */
+    public void selectLine() {
+        lineStart(SelectionPolicy.CLEAR);
+        lineEnd(SelectionPolicy.ADJUST);
+    }
+
+    /**
      * Moves caret to the previous page (i.e. page up)
      * @param selectionPolicy use {@link SelectionPolicy#CLEAR} when no selection is desired and
      *                        {@link SelectionPolicy#ADJUST} when a selection from starting point

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -145,6 +145,16 @@ class ParagraphBox<PS, SEG, S> extends Region {
         return new CaretOffsetX(text.getCaretOffsetX());
     }
 
+    public int getCurrentLineStartPosition() {
+        layout(); // ensure layout, is a no-op if not dirty
+        return text.getCurrentLineStartPosition();
+    }
+
+    public int getCurrentLineEndPosition() {
+        layout(); // ensure layout, is a no-op if not dirty
+        return text.getCurrentLineEndPosition();
+    }
+
     public int getLineCount() {
         layout(); // ensure layout, is a no-op if not dirty
         return text.getLineCount();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -161,6 +161,14 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         }
     }
 
+    public int getCurrentLineStartPosition() {
+        return getLineStartPosition(clampedCaretPosition.getValue());
+    }
+
+    public int getCurrentLineEndPosition() {
+        return getLineEndPosition(clampedCaretPosition.getValue());
+    }
+
     public int currentLineIndex() {
         return getLineOfCharacter(clampedCaretPosition.getValue());
     }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -97,8 +97,8 @@ class StyledTextAreaBehavior {
                 // caret movement
                 consume(anyOf(keyPressed(RIGHT), keyPressed(KP_RIGHT)), StyledTextAreaBehavior::right),
                 consume(anyOf(keyPressed(LEFT),  keyPressed(KP_LEFT)),  StyledTextAreaBehavior::left),
-                consume(keyPressed(HOME), (b, e) -> b.model.lineStart(SelectionPolicy.CLEAR)),
-                consume(keyPressed(END),  (b, e) -> b.model.lineEnd(SelectionPolicy.CLEAR)),
+                consume(keyPressed(HOME), (b, e) -> b.view.lineStart(SelectionPolicy.CLEAR)),
+                consume(keyPressed(END),  (b, e) -> b.view.lineEnd(SelectionPolicy.CLEAR)),
                 consume(
                         anyOf(
                                 keyPressed(RIGHT,    SHORTCUT_DOWN),
@@ -122,8 +122,8 @@ class StyledTextAreaBehavior {
                                 keyPressed(LEFT,     SHIFT_DOWN),
                                 keyPressed(KP_LEFT,  SHIFT_DOWN)
                         ), StyledTextAreaBehavior::selectLeft),
-                consume(keyPressed(HOME, SHIFT_DOWN),                (b, e) -> b.model.lineStart(selPolicy)),
-                consume(keyPressed(END,  SHIFT_DOWN),                (b, e) -> b.model.lineEnd(selPolicy)),
+                consume(keyPressed(HOME, SHIFT_DOWN),                (b, e) -> b.view.lineStart(selPolicy)),
+                consume(keyPressed(END,  SHIFT_DOWN),                (b, e) -> b.view.lineEnd(selPolicy)),
                 consume(keyPressed(HOME, SHIFT_DOWN, SHORTCUT_DOWN), (b, e) -> b.model.start(selPolicy)),
                 consume(keyPressed(END,  SHIFT_DOWN, SHORTCUT_DOWN), (b, e) -> b.model.end(selPolicy)),
                 consume(

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -407,7 +407,7 @@ class StyledTextAreaBehavior {
                 switch (e.getClickCount()) {
                     case 1: firstLeftPress(hit); break;
                     case 2: selectWord(); break;
-                    case 3: model.selectLine(); break;
+                    case 3: model.selectParagraph(); break;
                     default: // do nothing
                 }
             }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -58,6 +58,25 @@ class TextFlowExt extends TextFlow {
         return getLines().length;
     }
 
+    int getLineStartPosition(int charIdx) {
+        TextLine[] lines = getLines();
+        TwoLevelNavigator navigator = new TwoLevelNavigator(
+                () -> lines.length,
+                i -> lines[i].getLength());
+        int currentLineIndex = navigator.offsetToPosition(charIdx, Forward).getMajor();
+        return navigator.position(currentLineIndex, 0).toOffset();
+    }
+
+    int getLineEndPosition(int charIdx) {
+        TextLine[] lines = getLines();
+        TwoLevelNavigator navigator = new TwoLevelNavigator(
+                () -> lines.length,
+                i -> lines[i].getLength());
+        int currentLineIndex = navigator.offsetToPosition(charIdx, Forward).getMajor();
+        int minor = currentLineIndex == lines.length - 1 ? 0 : -1;
+        return navigator.position(currentLineIndex + 1, minor).toOffset();
+    }
+
     int getLineOfCharacter(int charIdx) {
         TextLine[] lines = getLines();
         TwoLevelNavigator navigator = new TwoLevelNavigator(

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/NavigationActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/NavigationActions.java
@@ -166,16 +166,16 @@ public interface NavigationActions<PS, SEG, S> extends TextEditingArea<PS, SEG, 
     }
 
     /**
-     * Moves the caret to the beginning of the current line.
+     * Moves the caret to the beginning of the current paragraph.
      */
-    default void lineStart(SelectionPolicy selectionPolicy) {
+    default void paragraphStart(SelectionPolicy selectionPolicy) {
         moveTo(getCaretPosition() - getCaretColumn(), selectionPolicy);
     }
 
     /**
-     * Moves the caret to the end of the current line.
+     * Moves the caret to the end of the current paragraph.
      */
-    default void lineEnd(SelectionPolicy selectionPolicy) {
+    default void paragraphEnd(SelectionPolicy selectionPolicy) {
         int lineLen = getText(getCurrentParagraph()).length();
         int newPos = getCaretPosition() - getCaretColumn() + lineLen;
         moveTo(newPos, selectionPolicy);
@@ -198,9 +198,9 @@ public interface NavigationActions<PS, SEG, S> extends TextEditingArea<PS, SEG, 
     /**
      * Selects the current line.
      */
-    default void selectLine() {
-        lineStart(SelectionPolicy.CLEAR);
-        lineEnd(SelectionPolicy.ADJUST);
+    default void selectParagraph() {
+        paragraphStart(SelectionPolicy.CLEAR);
+        paragraphEnd(SelectionPolicy.ADJUST);
     }
 
     /**


### PR DESCRIPTION
> The methods lineStart and lineEnd move the cursor to the start and end of the paragraph, not the line. Their names should be changed to paragraphStart and paragraphEnd to avoid confusion, as well as renaming selectLine to selectParagraph.

> When pressing either Home or End, the caret position should change relative to the current line, not the current paragraph, which is what users have come to expect (e.g., the text area used to write this message has typical home/end key behaviour). There are a few related issues: #384 and #360.