### PR TITLE
Fix -fx-highlight-text-fill (selected text color) (issue #303)

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -24,9 +24,6 @@ import org.reactfx.value.Var;
 
 class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
-    // FIXME: changing it currently has not effect, because
-    // Text.impl_selectionFillProperty().set(newFill) doesn't work
-    // properly for Text node inside a TextFlow (as of JDK8-b100).
     private final ObjectProperty<Paint> highlightTextFill = new SimpleObjectProperty<>(Color.WHITE);
     public ObjectProperty<Paint> highlightTextFillProperty() {
         return highlightTextFill;
@@ -86,20 +83,12 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         caretShape.layoutYProperty().bind(topInset);
         getChildren().add(caretShape);
 
-        // XXX: see the note at highlightTextFill
-//        highlightTextFill.addListener(new ChangeListener<Paint>() {
-//            @Override
-//            public void changed(ObservableValue<? extends Paint> observable,
-//                    Paint oldFill, Paint newFill) {
-//                for(PumpedUpText text: textNodes())
-//                    text.impl_selectionFillProperty().set(newFill);
-//            }
-//        });
-
         // populate with text nodes
         for(SEG segment: par.getSegments()) {
             // create Segment
             Node fxNode = nodeFactory.apply(segment);
+            if(fxNode instanceof TextExt)
+                ((TextExt)fxNode).impl_selectionFillProperty().bind(highlightTextFill);
             getChildren().add(fxNode);
 
             // add corresponding background node (empty)
@@ -183,6 +172,35 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         int end = selection.get().getEnd();
         PathElement[] shape = getRangeShape(start, end);
         selectionShape.getElements().setAll(shape);
+    }
+
+    // XXX: Because of JDK bug https://bugs.openjdk.java.net/browse/JDK-8149134
+    //      this does not work correctly if a paragraph contains more than one segment
+    //      and the selection is (also) in the second or later segments.
+    //      Visually the text color of the selection may be mix black & white.
+    private void updateTextSelection() {
+        int selStart = selection.get().getStart();
+        int selEnd = selection.get().getEnd();
+
+        int start = 0;
+        FilteredList<Node> nodeList = getChildren().filtered(node -> node instanceof TextExt);
+        for (Node node : nodeList) {
+            TextExt text = (TextExt) node;
+            int end = start + text.getText().length();
+
+            int textSelStart = Math.max(start, selStart);
+            int textSelEnd = Math.min(end, selEnd);
+            if (textSelEnd > textSelStart) {
+                textSelStart -= start;
+                textSelEnd -= start;
+            } else {
+                textSelStart = textSelEnd = -1;
+            }
+            text.setImpl_selectionStart(textSelStart);
+            text.setImpl_selectionEnd(textSelEnd);
+
+            start = end;
+        }
     }
 
     private void updateBackgroundShapes() {
@@ -290,6 +308,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         super.layoutChildren();
         updateCaretShape();
         updateSelectionShape();
+        updateTextSelection();
         updateBackgroundShapes();
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -103,9 +103,6 @@ public class StyledTextArea<PS, S> extends GenericStyledArea<PS, StyledText<S>, 
         t.getStyleClass().add("text");
         applyStyle.accept(t, segOps.getStyle(seg));
 
-        // XXX: binding selectionFill to textFill,
-        // see the note at highlightTextFill
-        t.impl_selectionFillProperty().bind(t.fillProperty());
         return t;
     }
 }


### PR DESCRIPTION
**Note**: this PR should be **not yet merged into master** because it does not work correctly as long as the JDK bug (see below) is not fixed. Created the PR to avoid that the fix is lost...

This PR attempts to fix text color of selection (white selected text), BUT:
Because of JDK bug https://bugs.openjdk.java.net/browse/JDK-8149134
this does not work correctly if a paragraph contains more than one segment
and the selection is (also) in the second or later segments.
Visually the text color of the selection may be mix black & white.
Sometimes text becomes invisible (white text on white background).

Mixed text selection color:

![image](https://cloud.githubusercontent.com/assets/12702749/22015988/c35879ba-dca4-11e6-9b8b-73a48afec861.png)

Sometimes makes text invisible:

![image](https://cloud.githubusercontent.com/assets/12702749/22016135/692058fe-dca5-11e6-837d-aa2190020d35.png)
