### PR TITLE
Resolve javadoc links to Flowless (0.5.0)

### DIFF
--- a/richtextfx/build.gradle
+++ b/richtextfx/build.gradle
@@ -33,7 +33,10 @@ javadoc {
         'http://docs.oracle.com/javase/8/javafx/api/',
 
         // resolve links to ReactFX
-        'http://www.reactfx.org/javadoc/2.0-M5/'
+        'http://www.reactfx.org/javadoc/2.0-M5/',
+            
+        // resolve links to Flowless
+        'https://fxmisc.github.io/flowless/javadoc/0.5/'
     ]
 }
 


### PR DESCRIPTION
- Note: current Flowless version in use is 0.5.1, but updating to that link did not work.