### PR TITLE
Update custom object example to use interface

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/EmptyLinkedImage.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/EmptyLinkedImage.java
@@ -1,0 +1,26 @@
+package org.fxmisc.richtext.demo.richtext;
+
+import javafx.scene.Node;
+
+public class EmptyLinkedImage<S> implements LinkedImage<S> {
+
+    @Override
+    public LinkedImage<S> setStyle(S style) {
+        return this;
+    }
+
+    @Override
+    public S getStyle() {
+        return null;
+    }
+
+    @Override
+    public String getImagePath() {
+        return "";
+    }
+
+    @Override
+    public Node createNode() {
+        throw new AssertionError("Unreachable code");
+    }
+}

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/LinkedImage.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/LinkedImage.java
@@ -1,25 +1,14 @@
 package org.fxmisc.richtext.demo.richtext;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.IOException;
-
 import javafx.scene.Node;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-
 import org.fxmisc.richtext.model.Codec;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
-/**
- * A custom object which contains a file path to an image file.
- * When rendered in the rich text editor, the image is loaded from the
- * specified file.
- */
-public class LinkedImage<S> {
-
-    public static <S> Codec<LinkedImage<S>> codec(Codec<S> styleCodec) {
+public interface LinkedImage<S> {
+    static <S> Codec<LinkedImage<S>> codec(Codec<S> styleCodec) {
         return new Codec<LinkedImage<S>>() {
 
             @Override
@@ -29,72 +18,35 @@ public class LinkedImage<S> {
 
             @Override
             public void encode(DataOutputStream os, LinkedImage<S> i) throws IOException {
-                // external path rep should use forward slashes only
-                String externalPath = i.imagePath.replace("\\", "/");
-                Codec.STRING_CODEC.encode(os, externalPath);
-                styleCodec.encode(os, i.style);
+                // don't encode EmptyLinkedImage objects
+                if (i.getStyle() != null) {
+                    // external path rep should use forward slashes only
+                    String externalPath = i.getImagePath().replace("\\", "/");
+                    Codec.STRING_CODEC.encode(os, externalPath);
+                    styleCodec.encode(os, i.getStyle());
+                }
             }
 
             @Override
-            public LinkedImage<S> decode(DataInputStream is) throws IOException {
+            public RealLinkedImage<S> decode(DataInputStream is) throws IOException {
                 // Sanitize path - make sure that forward slashes only are used
                 String imagePath = Codec.STRING_CODEC.decode(is);
                 imagePath = imagePath.replace("\\",  "/");
                 S style = styleCodec.decode(is);
-                return new LinkedImage<>(imagePath, style);
+                return new RealLinkedImage<>(imagePath, style);
             }
 
         };
     }
 
-    private final String imagePath;
-    private final S style;
+    LinkedImage<S> setStyle(S style);
 
-    /**
-     * Creates a new linked image object.
-     *
-     * @param imagePath The path to the image file.
-     * @param style The text style to apply to the corresponding segment.
-     */
-    public LinkedImage(String imagePath, S style) {
-
-        // if the image is below the current working directory,
-        // then store as relative path name.
-        String currentDir = System.getProperty("user.dir") + File.separatorChar;
-        if (imagePath.startsWith(currentDir)) {
-            imagePath = imagePath.substring(currentDir.length());
-        }
-
-        this.imagePath = imagePath;
-        this.style = style;
-    }
-
-    public LinkedImage<S> setStyle(S style) {
-        return new LinkedImage<>(imagePath, style);
-    }
-
+    S getStyle();
 
     /**
      * @return The path of the image to render.
      */
-    public String getImagePath() {
-        return imagePath;
-    }
+    String getImagePath();
 
-    public S getStyle() {
-        return style;
-    }
-
-
-    @Override
-    public String toString() {
-        return String.format("LinkedImage[path=%s]", imagePath);
-    }
-
-    public Node createNode() {
-        Image image = new Image("file:" + imagePath); // XXX: No need to create new Image objects each time -
-                                                      // could be cached in the model layer
-        ImageView result = new ImageView(image);
-        return result;
-    }
+    Node createNode();
 }

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/LinkedImageOps.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/LinkedImageOps.java
@@ -6,7 +6,7 @@ import org.fxmisc.richtext.model.SegmentOps;
 
 public class LinkedImageOps<S> implements SegmentOps<LinkedImage<S>, S> {
 
-    private final LinkedImage<S> emptySeg = new LinkedImage<>("", null);
+    private final EmptyLinkedImage<S> emptySeg = new EmptyLinkedImage<>();
 
     @Override
     public int length(LinkedImage<S> seg) {

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RealLinkedImage.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RealLinkedImage.java
@@ -1,0 +1,68 @@
+package org.fxmisc.richtext.demo.richtext;
+
+import java.io.File;
+
+import javafx.scene.Node;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+
+
+/**
+ * A custom object which contains a file path to an image file.
+ * When rendered in the rich text editor, the image is loaded from the
+ * specified file.
+ */
+public class RealLinkedImage<S> implements LinkedImage<S> {
+
+    private final String imagePath;
+    private final S style;
+
+    /**
+     * Creates a new linked image object.
+     *
+     * @param imagePath The path to the image file.
+     * @param style The text style to apply to the corresponding segment.
+     */
+    public RealLinkedImage(String imagePath, S style) {
+
+        // if the image is below the current working directory,
+        // then store as relative path name.
+        String currentDir = System.getProperty("user.dir") + File.separatorChar;
+        if (imagePath.startsWith(currentDir)) {
+            imagePath = imagePath.substring(currentDir.length());
+        }
+
+        this.imagePath = imagePath;
+        this.style = style;
+    }
+
+    @Override
+    public RealLinkedImage<S> setStyle(S style) {
+        return new RealLinkedImage<>(imagePath, style);
+    }
+
+
+    @Override
+    public String getImagePath() {
+        return imagePath;
+    }
+
+    @Override
+    public S getStyle() {
+        return style;
+    }
+
+
+    @Override
+    public String toString() {
+        return String.format("RealLinkedImage[path=%s]", imagePath);
+    }
+
+    @Override
+    public Node createNode() {
+        Image image = new Image("file:" + imagePath); // XXX: No need to create new Image objects each time -
+                                                      // could be cached in the model layer
+        ImageView result = new ImageView(image);
+        return result;
+    }
+}

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichText.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichText.java
@@ -439,7 +439,7 @@ public class RichText extends Application {
             String imagePath = selectedFile.getAbsolutePath();
             imagePath = imagePath.replace('\\',  '/');
             ReadOnlyStyledDocument<ParStyle, Either<StyledText<TextStyle>, LinkedImage<TextStyle>>, TextStyle> ros =
-                    ReadOnlyStyledDocument.fromSegment(Either.right(new LinkedImage<>(imagePath, TextStyle.EMPTY)),
+                    ReadOnlyStyledDocument.fromSegment(Either.right(new RealLinkedImage<>(imagePath, TextStyle.EMPTY)),
                                                        ParStyle.EMPTY, TextStyle.EMPTY, area.getSegOps());
             area.replaceSelection(ros);
         }


### PR DESCRIPTION
I think turning `LinkedImage` into an interface with an empty and non-empty classes better shows how one should implement a custom object. It cleans up the code logic in what's now called `RealLinkedImage` due to no longer accounting for the possibility of it being the empty version.