### PR TITLE
Add context menu

### DIFF
--- a/richtextfx/build.gradle
+++ b/richtextfx/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     testCompile ("org.testfx:testfx-junit:4.0.5-alpha") {
         exclude(group: "junit", module: "junit")
     }
+    testCompile group: 'com.nitorcreations', name: 'junit-runners', version: '1.2'
 }
 
 javadoc {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -41,6 +41,7 @@ import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.IndexRange;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
@@ -274,6 +275,29 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     public void setParagraphGraphicFactory(IntFunction<? extends Node> factory) { paragraphGraphicFactory.set(factory); }
     public IntFunction<? extends Node> getParagraphGraphicFactory() { return paragraphGraphicFactory.get(); }
     public ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactoryProperty() { return paragraphGraphicFactory; }
+
+    /** The {@link ContextMenu} for the area, which is by default null. */
+    private ObjectProperty<ContextMenu> contextMenu = new SimpleObjectProperty<>(null);
+    public final ContextMenu getContextMenu() { return contextMenu.get(); }
+    public final void setContextMenu(ContextMenu menu) { contextMenu.setValue(menu); }
+    public final ObjectProperty<ContextMenu> contextMenuObjectProperty() { return contextMenu; }
+    protected final boolean isContextMenuPresent() { return contextMenu.get() != null; }
+
+    /**
+     * The horizontal amount in pixels by which to offset the {@link #contextMenu} when it is shown, which has
+     * a default value of 2.
+     */
+    private double contextMenuXOffset = 2;
+    public final double getContextMenuXOffset() { return contextMenuXOffset; }
+    public final void setContextMenuXOffset(double offset) { contextMenuXOffset = offset; }
+
+    /**
+     * The vertical amount in pixels by which to offset the {@link #contextMenu} when it is shown, which has
+     * a default value of 2.
+     */
+    private double contextMenuYOffset = 2;
+    public final double getContextMenuYOffset() { return contextMenuYOffset; }
+    public final void setContextMenuYOffset(double offset) { contextMenuYOffset = offset; }
 
     /**
      * Indicates whether the initial style should also be used for plain text

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -1,0 +1,92 @@
+package org.fxmisc.richtext.model;
+
+import com.nitorcreations.junit.runners.NestedRunner;
+import javafx.scene.Scene;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.stage.Stage;
+import org.fxmisc.flowless.VirtualizedScrollPane;
+import org.fxmisc.richtext.InlineCssTextArea;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testfx.framework.junit.ApplicationTest;
+
+@RunWith(NestedRunner.class)
+public class StyledTextAreaBehaviorTest {
+
+    static {
+        String osName = System.getProperty("os.name").toLowerCase();
+
+        WINDOWS_OS = osName.contains("win");
+    }
+
+    private static final boolean WINDOWS_OS;
+
+    public class ContextMenuTests extends ApplicationTest {
+
+        public InlineCssTextArea area = new InlineCssTextArea();
+
+        @Override
+        public void start(Stage stage) throws Exception {
+            area.setContextMenu(new ContextMenu(new MenuItem("A Menu Item")));
+            // offset needs to be 5 to prevent test failures
+            area.setContextMenuXOffset(5);
+            area.setContextMenuYOffset(5);
+
+            VirtualizedScrollPane<InlineCssTextArea> pane = new VirtualizedScrollPane<>(area);
+            stage.setScene(new Scene(pane, 500, 500));
+            stage.show();
+        }
+
+        @Test
+        public void clickingSecondaryShowsContextMenu() {
+            // when
+            rightClickOn(area);
+
+            // then
+            area.getContextMenu().isShowing();
+        }
+
+        @Test
+        public void pressingSecondaryShowsContextMenu() {
+            // when
+            moveTo(area);
+            press(MouseButton.SECONDARY);
+
+            // then
+            area.getContextMenu().isShowing();
+        }
+
+        @Test
+        public void pressingPrimaryMouseButtonHidesContextMenu() {
+            // given menu is showing
+            rightClickOn(area);
+
+            press(MouseButton.PRIMARY);
+            assert !area.getContextMenu().isShowing();
+        }
+
+        @Test
+        public void pressingMiddleMouseButtonHidesContextMenu() {
+            // given menu is showing
+            rightClickOn(area);
+
+            press(MouseButton.MIDDLE);
+            assert !area.getContextMenu().isShowing();
+        }
+
+        @Test
+        public void requestingContextMenuViaKeyboardWorksOnWindows() {
+            if (WINDOWS_OS) {
+                clickOn(area);
+                press(KeyCode.CONTEXT_MENU);
+
+                assert area.getContextMenu().isShowing();
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
This addresses #363.

There is no `ContextMenu` by default: this matches the same behavior as all other nodes.

### Questions
- Should the default offset values be `5` or some positive non-zero value? In the TestFX test, having it as zero will fail the tests because the mouse clicks on the menu rather than the area once it is shown. Developer who set the menu in their code will also need to override the default values every time, which is unnecessary boilerplate.
    - **Edit:** I've updated the PR to set the default offset values to `2`. There's no specific reason for this choice, so it's up for modification.