### PR TITLE
Add feature: get character bounds on screen

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1392,6 +1392,72 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         });
     }
 
+    /**
+     * Gets the character bounds on screen
+     *
+     * @param from the start position
+     * @param to the end position
+     * @return the bounds or {@link Optional#empty()} if line is not visible
+     */
+    public Optional<Bounds> getCharacterBoundsOnScreen(int from, int to) {
+        if (from < 0) {
+            throw new IllegalArgumentException("From is negative: " + from);
+        }
+        if (from > to) {
+            throw new IllegalArgumentException(String.format("From is greater than to. from=%s to=%s", from, to));
+        }
+        if (to > getLength()) {
+            throw new IllegalArgumentException(String.format("To is greater than area's length. length=%s, to=%s", getLength(), to));
+        }
+
+        // no bounds exist if range is just a newline character
+        if (getText(from, to).equals("\n")) {
+            return Optional.empty();
+        }
+
+        // if 'from' is the newline character at the end of a multi-line paragraph, it returns a Bounds that whose
+        //  minX & minY are the minX and minY of the paragraph itself, not the newline character. So, ignore it.
+        int realFrom = getText(from, from + 1).equals("\n") ? from + 1 : from;
+
+        Position startPosition = offsetToPosition(realFrom, Bias.Forward);
+        int startRow = startPosition.getMajor();
+        Position endPosition = startPosition.offsetBy(to - realFrom, Bias.Forward);
+        int endRow = endPosition.getMajor();
+        if (startRow == endRow) {
+            return getRangeBoundsOnScreen(startRow, startPosition.getMinor(), endPosition.getMinor());
+        } else {
+            Optional<Bounds> rangeBounds = getRangeBoundsOnScreen(startRow, startPosition.getMinor(),
+                    getParagraph(startRow).length());
+            for (int i = startRow + 1; i <= endRow; i++) {
+                Optional<Bounds> nextLineBounds = getRangeBoundsOnScreen(i, 0,
+                        i == endRow
+                            ? endPosition.getMinor()
+                            : getParagraph(i).length()
+                );
+                if (nextLineBounds.isPresent()) {
+                    if (rangeBounds.isPresent()) {
+                        Bounds lineBounds = nextLineBounds.get();
+                        rangeBounds = rangeBounds.map(b -> {
+                            double minX = Math.min(b.getMinX(),   lineBounds.getMinX());
+                            double minY = Math.min(b.getMinY(),   lineBounds.getMinY());
+                            double maxX = Math.max(b.getMaxX(),   lineBounds.getMaxX());
+                            double maxY = Math.max(b.getMaxY(),   lineBounds.getMaxY());
+                            return new BoundingBox(minX, minY, maxX - minX, maxY - minY);
+                        });
+                    } else {
+                        rangeBounds = nextLineBounds;
+                    }
+                }
+            }
+            return rangeBounds;
+        }
+    }
+
+    private Optional<Bounds> getRangeBoundsOnScreen(int paragraphIndex, int from, int to) {
+        return virtualFlow.getCellIfVisible(paragraphIndex)
+                .map(c -> c.getNode().getRangeBoundsOnScreen(from, to));
+    }
+
     private Optional<Bounds> getCaretBoundsOnScreen() {
         return virtualFlow.getCellIfVisible(getCurrentParagraph())
                 .map(c -> c.getNode().getCaretBoundsOnScreen());

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -181,6 +181,11 @@ class ParagraphBox<PS, SEG, S> extends Region {
         return text.getSelectionBoundsOnScreen();
     }
 
+    public Bounds getRangeBoundsOnScreen(int from, int to) {
+        layout(); // ensure layout, is a no-op if not dirty
+        return text.getRangeBoundsOnScreen(from, to);
+    }
+
     @Override
     protected double computeMinWidth(double ignoredHeight) {
         return computePrefWidth(-1);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -151,6 +151,20 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         return caretShape.localToScreen(localBounds);
     }
 
+    public Bounds getRangeBoundsOnScreen(int from, int to) {
+        layout(); // ensure layout, is a no-op if not dirty
+        PathElement[] rangeShape = getRangeShape(from, to);
+
+        // switch out shapes to calculate the bounds on screen
+        List<PathElement> selShape = selectionShape.getElements();
+        selectionShape.getElements().setAll(rangeShape);
+        Bounds localBounds = selectionShape.getBoundsInLocal();
+        Bounds rangeBoundsOnScreen = selectionShape.localToScreen(localBounds);
+        selectionShape.getElements().setAll(selShape);
+
+        return rangeBoundsOnScreen;
+    }
+
     public Optional<Bounds> getSelectionBoundsOnScreen() {
         if(selection.get().getLength() == 0) {
             return Optional.empty();


### PR DESCRIPTION
A few questions I have:

- Should `selectionShape` be used to get the bounds? Will that switch-out approach cause any issues later on? I didn't want to create a new `Path` object each time the method is called so as to reduce memory usage.
- I used the `FORWARD` bias in `endPosition = offsetToPosition(to, Bias.FORWARD)`. Is that correct? Or should it be `BACKWARD`? I still don't understand how that part of the code works.