### PR TITLE
Ignore test due to TestFX issue (should re-enable when fixed)

### DIFF
--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -9,6 +9,7 @@ import javafx.scene.input.MouseButton;
 import javafx.stage.Stage;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.InlineCssTextArea;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testfx.framework.junit.ApplicationTest;
@@ -77,11 +78,12 @@ public class StyledTextAreaBehaviorTest {
             assert !area.getContextMenu().isShowing();
         }
 
+        @Ignore // push(CONTEXT_MENU) does not create a ContextMenuEvent properly, causing test to fail
         @Test
         public void requestingContextMenuViaKeyboardWorksOnWindows() {
             if (WINDOWS_OS) {
                 clickOn(area);
-                press(KeyCode.CONTEXT_MENU);
+                push(KeyCode.CONTEXT_MENU);
 
                 assert area.getContextMenu().isShowing();
             }


### PR DESCRIPTION
Addresses #454 

On another note, the test should be using `push` rather than `press` as the former releases the key whereas the latter simply holds it down until the test ends.