### PR TITLE
Split up mouse handling so that overriding default mouse behavior does not affect other default behavior

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1147,6 +1147,16 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         }
     }
 
+    /**
+     * Hides the area's context menu if it is not {@code null} and it is {@link ContextMenu#isShowing() showing}.
+     */
+    public final void hideContextMenu() {
+        ContextMenu menu = getContextMenu();
+        if (menu != null && menu.isShowing()) {
+            menu.hide();
+        }
+    }
+
     @Override
     public void setStyle(int from, int to, S style) {
         content.setStyle(from, to, style);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -15,7 +15,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
 import java.util.function.IntSupplier;
 import java.util.function.IntUnaryOperator;
@@ -47,6 +46,7 @@ import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.IndexRange;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
@@ -159,12 +159,75 @@ import org.reactfx.value.Var;
  *
  * <h3>Overriding default mouse behavior</h3>
  *
- * The area's default mouse behavior cannot be partially overridden without it affecting other behavior (to do so,
- * one would need to re-implement the entire default behavior with one minor adjustment). Rather, one should
- * override the default mouse behavior by changing what happens at various events.
- * For example, {@link #getOnSelectionDrop()} overrides what happens when some portion of the area's content is
- * selected, then the mouse is pressed on that selection, the mouse moves to a new location, and the mouse is released.
- * At that point, {@link #onSelectionDrop} is used to determine what should happen.
+ * The area's default mouse behavior properly handles auto-scrolling and dragging the selected text to a new location.
+ * As such, some parts cannot be partially overridden without it affecting other behavior.
+ *
+ * <p>The following lists either {@link org.fxmisc.wellbehaved.event.EventPattern}s that cannot be overridden without
+ * negatively affecting the default mouse behavior or describe how to safely override things in a special way without
+ * disrupting the auto scroll behavior.</p>
+ * <ul>
+ *     <li>
+ *         <em>First (1 click count) Primary Button Mouse Pressed Events:</em>
+ *         (<code>EventPattern.mousePressed(MouseButton.PRIMARY).onlyIf(e -&gt; e.getClickCount() == 1)</code>).
+ *         Do not override. Instead, use {@link #onOutsideSelectionMousePress},
+ *         {@link #onInsideSelectionMousePressRelease}, or see next item.
+ *     </li>
+ *     <li>(
+ *         <em>All Other Mouse Pressed Events (e.g., Primary with 2+ click count):</em>
+ *         Aside from hiding the context menu if it is showing (use {@link #hideContextMenu()} some((where in your
+ *         overriding InputMap to maintain this behavior), these can be safely overridden via any of the
+ *         {@link org.fxmisc.wellbehaved.event.template.InputMapTemplate InputMapTemplate's factory methods} or
+ *         {@link org.fxmisc.wellbehaved.event.InputMap InputMap's factory methods}.
+ *     </li>
+ *     <li>
+ *         <em>Primary-Button-only Mouse Drag Detection Events:</em>
+ *         (<code>EventPattern.eventType(MouseEvent.DRAG_DETECTED).onlyIf(e -&gt; e.getButton() == MouseButton.PRIMARY &amp;&amp; !e.isMiddleButtonDown() &amp;&amp; !e.isSecondaryButtonDown())</code>).
+ *         Do not override. Instead, use {@link #onNewSelectionDrag} or {@link #onSelectionDrag}.
+ *     </li>
+ *     <li>
+ *         <em>Primary-Button-only Mouse Drag Events:</em>
+ *         (<code>EventPattern.mouseDragged().onlyIf(e -&gt; e.getButton() == MouseButton.PRIMARY &amp;&amp; !e.isMiddleButtonDown() &amp;&amp; !e.isSecondaryButtonDown())</code>)
+ *         Do not override, but see next item.
+ *     </li>
+ *     <li>
+ *         <em>All Other Mouse Drag Events:</em>
+ *         You may safely override other Mouse Drag Events using different
+ *         {@link org.fxmisc.wellbehaved.event.EventPattern}s without affecting default behavior only if
+ *         process InputMaps (
+ *         {@link org.fxmisc.wellbehaved.event.template.InputMapTemplate#process(javafx.event.EventType, BiFunction)},
+ *         {@link org.fxmisc.wellbehaved.event.template.InputMapTemplate#process(org.fxmisc.wellbehaved.event.EventPattern, BiFunction)},
+ *         {@link org.fxmisc.wellbehaved.event.InputMap#process(javafx.event.EventType, Function)}, or
+ *         {@link org.fxmisc.wellbehaved.event.InputMap#process(org.fxmisc.wellbehaved.event.EventPattern, Function)}
+ *         ) are used and {@link org.fxmisc.wellbehaved.event.InputHandler.Result#PROCEED} is returned.
+ *         The area has a "catch all" Mouse Drag InputMap that will auto scroll towards the mouse drag event when it
+ *         occurs outside the bounds of the area and will stop auto scrolling when the mouse event occurs within the
+ *         area. However, this only works if the event is not consumed before the event reaches that InputMap.
+ *         To insure the auto scroll feature is enabled, set {@link #isAutoScrollOnDragDesired()} to true in your
+ *         process InputMap. If the feature is not desired for that specific drag event, set it to false in the
+ *         process InputMap.
+ *         <em>Note: Due to this "catch-all" nature, all Mouse Drag Events are consumed.</em>
+ *     </li>
+ *     <li>
+ *         <em>Primary-Button-only Mouse Released Events:</em>
+ *         (<code>EventPattern.mouseReleased().onlyIf(e -&gt; e.getButton() == MouseButton.PRIMARY &amp;&amp; !e.isMiddleButtonDown() &amp;&amp; !e.isSecondaryButtonDown())</code>).
+ *         Do not override. Instead, use {@link #onNewSelectionDragEnd}, {@link #onSelectionDrop}, or see next item.
+ *     </li>
+ *     <li>
+ *         <em>All other Mouse Released Events:</em>
+ *         You may override other Mouse Released Events using different
+ *         {@link org.fxmisc.wellbehaved.event.EventPattern}s without affecting default behavior only if
+ *         process InputMaps (
+ *         {@link org.fxmisc.wellbehaved.event.template.InputMapTemplate#process(javafx.event.EventType, BiFunction)},
+ *         {@link org.fxmisc.wellbehaved.event.template.InputMapTemplate#process(org.fxmisc.wellbehaved.event.EventPattern, BiFunction)},
+ *         {@link org.fxmisc.wellbehaved.event.InputMap#process(javafx.event.EventType, Function)}, or
+ *         {@link org.fxmisc.wellbehaved.event.InputMap#process(org.fxmisc.wellbehaved.event.EventPattern, Function)}
+ *         ) are used and {@link org.fxmisc.wellbehaved.event.InputHandler.Result#PROCEED} is returned.
+ *         The area has a "catch-all" InputMap that will consume all mouse released events and stop auto scroll if it
+ *         was scrolling. However, this only works if the event is not consumed before the event reaches that InputMap.
+ *         <em>Note: Due to this "catch-all" nature, all Mouse Released Events are consumed.</em>
+ *     </li>
+ * </ul>
+ *
  *
  * @param <PS> type of style that can be applied to paragraphs (e.g. {@link TextFlow}.
  * @param <SEG> type of segment used in {@link Paragraph}. Can be only text (plain or styled) or
@@ -266,9 +329,51 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public Duration getMouseOverTextDelay() { return mouseOverTextDelay.get(); }
     @Override public ObjectProperty<Duration> mouseOverTextDelayProperty() { return mouseOverTextDelay; }
 
-    private final Property<IntConsumer> onSelectionDrop = new SimpleObjectProperty<>(this::moveSelectedText);
-    @Override public final void setOnSelectionDrop(IntConsumer consumer) { onSelectionDrop.setValue(consumer); }
-    @Override public final IntConsumer getOnSelectionDrop() { return onSelectionDrop.getValue(); }
+    private final BooleanProperty autoScrollOnDragDesired = new SimpleBooleanProperty(true);
+    public final void setAutoScrollOnDragDesired(boolean val) { autoScrollOnDragDesired.set(val); }
+    public final boolean isAutoScrollOnDragDesired() { return autoScrollOnDragDesired.get(); }
+
+    private final Property<Consumer<MouseEvent>> onOutsideSelectionMousePress = new SimpleObjectProperty<>(e -> {
+        CharacterHit hit = hit(e.getX(), e.getY());
+        moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
+    });
+    public final void setOnOutsideSelectionMousePress(Consumer<MouseEvent> consumer) { onOutsideSelectionMousePress.setValue(consumer); }
+    public final Consumer<MouseEvent> getOnOutsideSelectionMousePress() { return onOutsideSelectionMousePress.getValue(); }
+
+    private final Property<Consumer<MouseEvent>> onInsideSelectionMousePressRelease = new SimpleObjectProperty<>(e -> {
+        CharacterHit hit = hit(e.getX(), e.getY());
+        moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
+    });
+    public final void setOnInsideSelectionMousePressRelease(Consumer<MouseEvent> consumer) { onInsideSelectionMousePressRelease.setValue(consumer); }
+    public final Consumer<MouseEvent> getOnInsideSelectionMousePressRelease() { return onInsideSelectionMousePressRelease.getValue(); }
+
+    private final Property<Consumer<Point2D>> onNewSelectionDrag = new SimpleObjectProperty<>(p -> {
+        CharacterHit hit = hit(p.getX(), p.getY());
+        moveTo(hit.getInsertionIndex(), SelectionPolicy.ADJUST);
+    });
+    public final void setOnNewSelectionDrag(Consumer<Point2D> consumer) { onNewSelectionDrag.setValue(consumer); }
+    public final Consumer<Point2D> getOnNewSelectionDrag() { return onNewSelectionDrag.getValue(); }
+
+    private final Property<Consumer<MouseEvent>> onNewSelectionDragEnd = new SimpleObjectProperty<>(e -> {
+        CharacterHit hit = hit(e.getX(), e.getY());
+        moveTo(hit.getInsertionIndex(), SelectionPolicy.ADJUST);
+    });
+    public final void setOnNewSelectionDragEnd(Consumer<MouseEvent> consumer) { onNewSelectionDragEnd.setValue(consumer); }
+    public final Consumer<MouseEvent> getOnNewSelectionDragEnd() { return onNewSelectionDragEnd.getValue(); }
+
+    private final Property<Consumer<Point2D>> onSelectionDrag = new SimpleObjectProperty<>(p -> {
+        CharacterHit hit = hit(p.getX(), p.getY());
+        displaceCaret(hit.getInsertionIndex());
+    });
+    public final void setOnSelectionDrag(Consumer<Point2D> consumer) { onSelectionDrag.setValue(consumer); }
+    public final Consumer<Point2D> getOnSelectionDrag() { return onSelectionDrag.getValue(); }
+
+    private final Property<Consumer<MouseEvent>> onSelectionDrop = new SimpleObjectProperty<>(e -> {
+        CharacterHit hit = hit(e.getX(), e.getY());
+        moveSelectedText(hit.getInsertionIndex());
+    });
+    @Override public final void setOnSelectionDrop(Consumer<MouseEvent> consumer) { onSelectionDrop.setValue(consumer); }
+    @Override public final Consumer<MouseEvent> getOnSelectionDrop() { return onSelectionDrop.getValue(); }
 
     private final ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactory = new SimpleObjectProperty<>(null);
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -603,7 +603,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 if (indexOfChange < caretPosition) {
                     // if caret is within the changed content, move it to indexOfChange
                     // otherwise offset it by changeLength
-                    positionCaret(
+                    displaceCaret(
                             caretPosition < endOfChange
                                     ? indexOfChange
                                     : caretPosition + changeLength
@@ -1134,6 +1134,19 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         moveTo(hit.getInsertionIndex(), selectionPolicy);
     }
 
+    /**
+     * Displaces the caret from the selection by positioning only the caret to the new location without
+     * also affecting the selection's {@link #getAnchor() anchor} or the {@link #getSelection() selection}.
+     * Do not confuse this method with {@link #moveTo(int)}, which is the normal way of moving the caret.
+     * This method can be used to achieve the special case of positioning the caret outside or inside the selection,
+     * as opposed to always being at the boundary. Use with care.
+     */
+    public void displaceCaret(int pos) {
+        try(Guard g = suspend(caretPosition, currentParagraph, caretColumn)) {
+            internalCaretPosition.setValue(pos);
+        }
+    }
+
     @Override
     public void setStyle(int from, int to, S style) {
         content.setStyle(from, to, style);
@@ -1446,18 +1459,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
 
     private Guard suspend(Suspendable... suspendables) {
         return Suspendable.combine(beingUpdated, Suspendable.combine(suspendables)).suspend();
-    }
-
-    /**
-     * Positions only the caret. Doesn't move the anchor and doesn't change
-     * the selection. Can be used to achieve the special case of positioning
-     * the caret outside or inside the selection, as opposed to always being
-     * at the boundary. Use with care.
-     */
-    void positionCaret(int pos) {
-        try(Guard g = suspend(caretPosition, currentParagraph, caretColumn)) {
-            internalCaretPosition.setValue(pos);
-        }
     }
 
     void clearTargetCaretOffset() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -477,7 +477,7 @@ class StyledTextAreaBehavior {
 
         if(dragSelection == DragState.DRAG ||
                 dragSelection == DragState.POTENTIAL_DRAG) { // MOUSE_DRAGGED may arrive even before DRAG_DETECTED
-            view.positionCaret(hit.getInsertionIndex());
+            view.displaceCaret(hit.getInsertionIndex());
         } else {
             view.moveTo(hit.getInsertionIndex(), SelectionPolicy.ADJUST);
         }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -319,11 +319,6 @@ class StyledTextAreaBehavior {
         view.nextChar(SelectionPolicy.ADJUST);
     }
 
-    private void selectWord() {
-        view.wordBreaksBackwards(1, SelectionPolicy.CLEAR);
-        view.wordBreaksForwards(1, SelectionPolicy.ADJUST);
-    }
-
     private void deletePrevWord(KeyEvent ignore) {
         int end = view.getCaretPosition();
 
@@ -422,7 +417,7 @@ class StyledTextAreaBehavior {
             } else {
                 switch (e.getClickCount()) {
                     case 1: firstLeftPress(hit); break;
-                    case 2: selectWord(); break;
+                    case 2: view.selectWord(); break;
                     case 3: view.selectParagraph(); break;
                     default: // do nothing
                 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -398,9 +398,7 @@ class StyledTextAreaBehavior {
             return;
         }
 
-        if (view.isContextMenuPresent() && view.getContextMenu().isShowing()) {
-            view.getContextMenu().hide();
-        }
+        view.hideContextMenu();
 
         if(e.getButton() == MouseButton.PRIMARY) {
             // ensure focus

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/NavigationActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/NavigationActions.java
@@ -166,6 +166,14 @@ public interface NavigationActions<PS, SEG, S> extends TextEditingArea<PS, SEG, 
     }
 
     /**
+     * Selects the word closest to the caret
+     */
+    default void selectWord() {
+        wordBreaksBackwards(1, SelectionPolicy.CLEAR);
+        wordBreaksForwards(1, SelectionPolicy.ADJUST);
+    }
+
+    /**
      * Moves the caret to the beginning of the current paragraph.
      */
     default void paragraphStart(SelectionPolicy selectionPolicy) {

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/InlineCssTextAreaAppTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/InlineCssTextAreaAppTest.java
@@ -1,0 +1,40 @@
+package org.fxmisc.richtext.model;
+
+
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.stage.Stage;
+import org.fxmisc.richtext.InlineCssTextArea;
+import org.testfx.framework.junit.ApplicationTest;
+import org.testfx.service.query.PointQuery;
+
+/**
+ * TestFX tests should subclass this if it needs to run tests on a simple area. Any view-related API needs to be
+ * wrapped in a {@link #interact(Runnable)} call, but model API does not need to be wrapped in it.
+ */
+public class InlineCssTextAreaAppTest extends ApplicationTest {
+
+
+    public InlineCssTextArea area;
+    public ContextMenu menu;
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        area = new InlineCssTextArea();
+        menu = new ContextMenu(new MenuItem("A menu item"));
+        area.setContextMenu(menu);
+
+        // offset needs to be 5 to prevent test failures
+        area.setContextMenuXOffset(5);
+        area.setContextMenuYOffset(5);
+
+        stage.setScene(new Scene(area, 400, 400));
+        stage.show();
+    }
+
+    public final PointQuery firstLineOfArea() {
+        return point(area).atPosition(Pos.TOP_LEFT).atOffset(5, 5);
+    }
+}

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -9,10 +9,15 @@ import javafx.scene.input.MouseButton;
 import javafx.stage.Stage;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.InlineCssTextArea;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testfx.framework.junit.ApplicationTest;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
 
 @RunWith(NestedRunner.class)
 public class StyledTextAreaBehaviorTest {
@@ -27,6 +32,7 @@ public class StyledTextAreaBehaviorTest {
 
     public class ContextMenuTests extends ApplicationTest {
 
+        // TODO: move this inside start method to insure instantiation occurs on JavaFX App Thread
         public InlineCssTextArea area = new InlineCssTextArea();
 
         @Override
@@ -87,6 +93,288 @@ public class StyledTextAreaBehaviorTest {
 
                 assert area.getContextMenu().isShowing();
             }
+        }
+
+    }
+
+    public class MouseBehaviorTests {
+
+        public class WhenAreaIsDisabled extends InlineCssTextAreaAppTest {
+
+            @Before
+            public void setup() {
+                interact(() -> {
+                    area.setDisable(true);
+                    area.replaceText("When Area Is Disabled Test: Some text goes here");
+                });
+            }
+
+            @Test
+            public void shiftClickingAreaDoesNothing() {
+                moveTo(firstLineOfArea())
+                        .moveBy(20, 0)
+                        .press(KeyCode.SHIFT)
+                        .press(MouseButton.PRIMARY)
+                        .release(KeyCode.SHIFT);
+
+                assertFalse(area.isFocused());
+
+                // cleanup
+                release(MouseButton.PRIMARY);
+            }
+
+            @Test
+            public void singleClickingAreaDoesNothing() {
+                clickOn(area);
+
+                assertFalse(area.isFocused());
+            }
+
+            @Test
+            public void doubleClickingAreaDoesNothing() {
+                doubleClickOn(area);
+
+                assertFalse(area.isFocused());
+            }
+
+            @Test
+            public void tripleClickingAreaDoesNothing() {
+                clickOn(area, MouseButton.PRIMARY).doubleClickOn(MouseButton.PRIMARY);
+
+                assertFalse(area.isFocused());
+            }
+
+            @Test
+            public void draggingTheMouseDoesNotSelectText() {
+                moveTo(firstLineOfArea())
+                        .press(MouseButton.PRIMARY)
+                        .moveBy(20, 0);
+
+                assertTrue(area.getSelectedText().isEmpty());
+
+                // cleanup
+                drop();
+            }
+
+            @Test
+            public void releasingTheMouseAfterDragDoesNothing() {
+                moveTo(firstLineOfArea())
+                        .press(MouseButton.PRIMARY)
+                        .dropBy(20, 0);
+
+                assertEquals(0, area.getCaretPosition());
+
+            }
+
+        }
+
+        public class WhenAreaIsEnabled {
+
+            public class AndTextIsNotSelected extends InlineCssTextAreaAppTest {
+
+                private String firstWord = "Some";
+                private String firstParagraph = firstWord + " text goes here";
+
+                @Before
+                public void setup() {
+                    interact(() -> area.replaceText(firstParagraph));
+                }
+
+                @Test
+                public void singleClickingAreaMovesCaretToThatPosition() {
+                    assertEquals(0, area.getCaretPosition());
+
+                    moveTo(firstLineOfArea())
+                            .moveBy(20, 0)
+                            .clickOn(MouseButton.PRIMARY);
+
+                    assertTrue(0 != area.getCaretPosition());
+                    // TODO: check that caret is moved exactly to where it should be
+                }
+
+                @Test
+                public void doubleClickingTextInAreaSelectsClosestWord() {
+                    moveTo(firstLineOfArea())
+                            .doubleClickOn(MouseButton.PRIMARY);
+
+                    assertEquals(firstWord, area.getSelectedText());
+                }
+
+                @Test
+                public void tripleClickingLineInAreaSelectsParagraph() {
+                    moveTo(firstLineOfArea())
+                            .clickOn(MouseButton.PRIMARY)
+                            .doubleClickOn(MouseButton.PRIMARY);
+
+                    assertEquals(firstParagraph, area.getSelectedText());
+                }
+
+                @Test
+                public void pressingMouseOverTextAndDraggingMouseSelectsText() {
+                    moveTo(firstLineOfArea())
+                            .press(MouseButton.PRIMARY)
+                            .moveBy(20, 0);
+
+                    assertFalse(area.getSelectedText().isEmpty());
+                }
+
+            }
+
+            public class AndTextIsSelected extends InlineCssTextAreaAppTest {
+
+                private String firstWord = "Some";
+                private String firstParagraph = firstWord + " text goes here";
+
+                @Test
+                public void singleClickingWithinSelectedTextMovesCaretToThatPosition() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph);
+                        area.selectAll();
+                    });
+
+                    moveTo(firstLineOfArea())
+                            .moveBy(20, 0)
+                            .clickOn(MouseButton.PRIMARY);
+
+                    assertTrue(0 != area.getCaretPosition());
+                }
+
+                @Test
+                public void doubleClickingWithinSelectedTextSelectsClosestWord() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph);
+                        area.selectAll();
+                    });
+
+                    moveTo(firstLineOfArea())
+                            .doubleClickOn(MouseButton.PRIMARY);
+
+                    assertEquals(firstWord, area.getSelectedText());
+                }
+
+                @Test
+                public void tripleClickingWithinSelectedTextSelectsParagraph() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph);
+                        area.selectAll();
+                    });
+
+                    moveTo(firstLineOfArea())
+                            .clickOn(MouseButton.PRIMARY)
+                            .doubleClickOn(MouseButton.PRIMARY);
+
+                    assertEquals(firstParagraph, area.getSelectedText());
+                }
+
+                @Test
+                public void singleClickingOutsideOfSelectedTextMovesCaretToThatPosition() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph + "\n" + "this is the selected text");
+                        area.selectRange(1, 0, 2, -1);
+                    });
+
+                    int caretPos = area.getCaretPosition();
+
+                    moveTo(firstLineOfArea())
+                            .moveBy(20, 0)
+                            .clickOn(MouseButton.PRIMARY);
+
+                    assertTrue(caretPos != area.getCaretPosition());
+                    // TODO: check that caret is moved exactly to where it should be
+
+                }
+
+                @Test
+                public void doubleClickingOutsideOfSelectedTextSelectsClosestWord() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph + "\n" + "this is the selected text");
+                        area.selectRange(1, 0, 2, -1);
+                    });
+
+                    moveTo(firstLineOfArea())
+                            .doubleClickOn(MouseButton.PRIMARY);
+
+                    assertEquals(firstWord, area.getSelectedText());
+                }
+
+                @Test
+                public void tripleClickingOutsideOfSelectedTextSelectsParagraph() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph + "\n" + "this is the selected text");
+                        area.selectRange(1, 0, 2, -1);
+                    });
+
+                    moveTo(firstLineOfArea())
+                            .clickOn(MouseButton.PRIMARY)
+                            .doubleClickOn(MouseButton.PRIMARY);
+
+                    assertEquals(firstParagraph, area.getSelectedText());
+                }
+
+                @Test
+                public void pressingMouseOnUnselectedTextAndDraggingMakesNewSelection() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph + "\n" + "this is the selected text");
+                        area.selectRange(1, 0, 2, -1);
+                    });
+
+                    String originalSelection = area.getSelectedText();
+
+                    moveTo(firstLineOfArea())
+                            .press(MouseButton.PRIMARY)
+                            .moveBy(20, 0);
+
+                    assertFalse(originalSelection.equals(area.getSelectedText()));
+                }
+
+                @Test
+                public void pressingMouseOnSelectionAndDraggingDisplacesCaret() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph + "\n" + "This is extra text");
+                        area.selectRange(0, firstWord.length());
+                    });
+
+                    String selText = area.getSelectedText();
+                    int caretPos = area.getCaretPosition();
+
+                    moveTo(firstLineOfArea())
+                            .press(MouseButton.PRIMARY)
+                            .moveBy(0, 14);
+
+                    assertTrue(caretPos != area.getCaretPosition());
+                    assertEquals(selText, area.getSelectedText());
+                }
+
+                @Test
+                public void pressingMouseOnSelectionAndDraggingAndReleasingMovesSelectedTextToThatPosition() {
+                    // setup
+                    interact(() -> {
+                        area.replaceText(firstParagraph + "\n" + "This is extra text");
+                        area.selectRange(0, firstWord.length());
+                    });
+
+                    String selText = area.getSelectedText();
+                    int caretPos = area.getCaretPosition();
+
+                    moveTo(firstLineOfArea())
+                            .press(MouseButton.PRIMARY)
+                            .dropBy(0, 14);
+
+                    assertTrue(caretPos != area.getCaretPosition());
+                    assertTrue(area.getSelectedText().isEmpty());
+                    // TODO: should check that move is exact
+                }
+
+            }
+
         }
 
     }

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -1,19 +1,12 @@
 package org.fxmisc.richtext.model;
 
 import com.nitorcreations.junit.runners.NestedRunner;
-import javafx.scene.Scene;
-import javafx.scene.control.ContextMenu;
-import javafx.scene.control.MenuItem;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
-import javafx.stage.Stage;
-import org.fxmisc.flowless.VirtualizedScrollPane;
-import org.fxmisc.richtext.InlineCssTextArea;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.testfx.framework.junit.ApplicationTest;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
@@ -30,22 +23,7 @@ public class StyledTextAreaBehaviorTest {
 
     private static final boolean WINDOWS_OS;
 
-    public class ContextMenuTests extends ApplicationTest {
-
-        // TODO: move this inside start method to insure instantiation occurs on JavaFX App Thread
-        public InlineCssTextArea area = new InlineCssTextArea();
-
-        @Override
-        public void start(Stage stage) throws Exception {
-            area.setContextMenu(new ContextMenu(new MenuItem("A Menu Item")));
-            // offset needs to be 5 to prevent test failures
-            area.setContextMenuXOffset(5);
-            area.setContextMenuYOffset(5);
-
-            VirtualizedScrollPane<InlineCssTextArea> pane = new VirtualizedScrollPane<>(area);
-            stage.setScene(new Scene(pane, 500, 500));
-            stage.show();
-        }
+    public class ContextMenuTests extends InlineCssTextAreaAppTest {
 
         @Test
         public void clickingSecondaryShowsContextMenu() {
@@ -53,7 +31,7 @@ public class StyledTextAreaBehaviorTest {
             rightClickOn(area);
 
             // then
-            area.getContextMenu().isShowing();
+            assertTrue(area.getContextMenu().isShowing());
         }
 
         @Test
@@ -63,7 +41,7 @@ public class StyledTextAreaBehaviorTest {
             press(MouseButton.SECONDARY);
 
             // then
-            area.getContextMenu().isShowing();
+            assertTrue(area.getContextMenu().isShowing());
         }
 
         @Test
@@ -72,7 +50,7 @@ public class StyledTextAreaBehaviorTest {
             rightClickOn(area);
 
             press(MouseButton.PRIMARY);
-            assert !area.getContextMenu().isShowing();
+            assertFalse(area.getContextMenu().isShowing());
         }
 
         @Test
@@ -81,7 +59,7 @@ public class StyledTextAreaBehaviorTest {
             rightClickOn(area);
 
             press(MouseButton.MIDDLE);
-            assert !area.getContextMenu().isShowing();
+            assertFalse(area.getContextMenu().isShowing());
         }
 
         @Ignore // push(CONTEXT_MENU) does not create a ContextMenuEvent properly, causing test to fail


### PR DESCRIPTION
I'm not going to merge this just yet. I'm going to write some TestFX tests that simulates the expected behavior of the mouse behavior before this PR's changes were added to it. Then I'll rebase the work here (and clean it up) to insure that the new code works exactly as the previous code. 