### PR TITLE
Fix regression: Update caret position after replace call

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1300,6 +1300,9 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override
     public void replace(int start, int end, StyledDocument<PS, SEG, S> replacement) {
         content.replace(start, end, replacement);
+
+        int newCaretPos = start + replacement.length();
+        selectRange(newCaretPos, newCaretPos);
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
@@ -122,6 +122,10 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
     @Override
     public void replace(int start, int end, StyledDocument<PS, SEG, S> replacement) {
         ensureValidRange(start, end);
+        if (replacement.length() == 0 && start == end) {
+            // ignore a replacement that doesn't do anything
+            return;
+        }
         doc.replace(start, end, ReadOnlyStyledDocument.from(replacement)).exec(this::update);
     }
 

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -84,6 +84,7 @@ public class StyledTextAreaBehaviorTest {
                 interact(() -> {
                     area.setDisable(true);
                     area.replaceText("When Area Is Disabled Test: Some text goes here");
+                    area.moveTo(0);
                 });
             }
 
@@ -136,6 +137,8 @@ public class StyledTextAreaBehaviorTest {
 
             @Test
             public void releasingTheMouseAfterDragDoesNothing() {
+                assertEquals(0, area.getCaretPosition());
+
                 moveTo(firstLineOfArea())
                         .press(MouseButton.PRIMARY)
                         .dropBy(20, 0);
@@ -155,7 +158,10 @@ public class StyledTextAreaBehaviorTest {
 
                 @Before
                 public void setup() {
-                    interact(() -> area.replaceText(firstParagraph));
+                    interact(() -> {
+                        area.replaceText(firstParagraph);
+                        area.moveTo(0);
+                    });
                 }
 
                 @Test

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -357,4 +357,23 @@ public class StyledTextAreaBehaviorTest {
 
     }
 
+    public class KeyboardBehaviorTests extends InlineCssTextAreaAppTest {
+
+        @Test
+        public void typingALetterMovesTheCaretAfterThatInsertedLetter() {
+            interact(() -> {
+                area.moveTo(0);
+                area.clear();
+            });
+
+            String userInputtedText = "some user-inputted text";
+            clickOn(area).write(userInputtedText);
+
+            assertEquals(userInputtedText, area.getText());
+            assertEquals(userInputtedText.length(), area.getCaretPosition());
+            assertTrue(area.getSelectedText().isEmpty());
+        }
+
+    }
+
 }


### PR DESCRIPTION
Turns out I didn't copy this code over into the view correctly because it mixed model and view API calls together