### PR TITLE
Fix line numbers alignment and change default padding to spaces. #488

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
@@ -3,6 +3,7 @@ package org.fxmisc.richtext;
 import java.util.function.IntFunction;
 
 import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Background;
@@ -57,6 +58,7 @@ public class LineNumberFactory implements IntFunction<Node> {
         lineNo.setBackground(DEFAULT_BACKGROUND);
         lineNo.setTextFill(DEFAULT_TEXT_FILL);
         lineNo.setPadding(DEFAULT_INSETS);
+        lineNo.setAlignment(Pos.TOP_RIGHT);
         lineNo.getStyleClass().add("lineno");
 
         // bind label's text to a Val that stops observing area's paragraphs

--- a/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
@@ -30,7 +30,7 @@ public class LineNumberFactory implements IntFunction<Node> {
             new Background(new BackgroundFill(Color.web("#ddd"), null, null));
 
     public static IntFunction<Node> get(GenericStyledArea<?, ?, ?> area) {
-        return get(area, digits -> "%0" + digits + "d");
+        return get(area, digits -> "%1$" + digits + "s");
     }
 
     public static IntFunction<Node> get(


### PR DESCRIPTION
Fixed line numbers alignment and changed default padding to spaces as discussed in #488

Before:
![](http://i.imgur.com/lPe1Rjy.png)

After:
![](http://i.imgur.com/ONjOgMY.png)