### PR TITLE
Support for setting stroke colour and width of background shapes in TextExt

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -18,6 +18,7 @@ import javafx.scene.shape.Path;
 import javafx.scene.shape.PathElement;
 import javafx.scene.shape.StrokeLineCap;
 
+import javafx.scene.shape.StrokeType;
 import org.fxmisc.richtext.model.Paragraph;
 import org.reactfx.value.Val;
 import org.reactfx.value.Var;
@@ -226,11 +227,20 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
      * @param index The index of the background shape
      */
     private void updateBackground(TextExt text, int start, int end, int index) {
-        // Set fill
-        Paint paint = text.backgroundColorProperty().get();
-        if (paint != null) {
+        Paint fill = text.backgroundColorProperty().get();
+        Paint stroke = text.backgroundStrokeProperty().get();
+        // Only need to draw background if fill or stroke (or both) is set:
+        if (fill != null || stroke != null) {
             Path backgroundShape = backgroundShapes.get(index);
-            backgroundShape.setFill(paint);
+            backgroundShape.setFill(fill);
+            backgroundShape.setStroke(stroke);
+            // Prevent adjacent shapes overlapping:
+            backgroundShape.setStrokeType(StrokeType.INSIDE);
+            Number strokeWidth = text.backgroundStrokeWidthProperty().get();
+            if (stroke != null && strokeWidth != null)
+            {
+                backgroundShape.setStrokeWidth(strokeWidth.doubleValue());
+            }
 
             // Set path elements
             PathElement[] shape = getRangeShape(start, end);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
@@ -48,6 +48,40 @@ public class TextExt extends Text {
         }
     };
 
+    private final StyleableObjectProperty<Paint> backgroundStroke = new StyleableObjectProperty<Paint>(null) {
+        @Override
+        public Object getBean() {
+            return TextExt.this;
+        }
+
+        @Override
+        public String getName() {
+            return "backgroundStroke";
+        }
+
+        @Override
+        public CssMetaData<TextExt, Paint> getCssMetaData() {
+            return StyleableProperties.BACKGROUND_STROKE;
+        }
+    };
+
+    private final StyleableObjectProperty<Number> backgroundStrokeWidth = new StyleableObjectProperty<Number>(1.0) {
+        @Override
+        public Object getBean() {
+            return TextExt.this;
+        }
+
+        @Override
+        public String getName() {
+            return "backgroundStrokeWidth";
+        }
+
+        @Override
+        public CssMetaData<TextExt, Number> getCssMetaData() {
+            return StyleableProperties.BACKGROUND_STROKE_WIDTH;
+        }
+    };
+
     private final StyleableObjectProperty<Paint> underlineColor = new StyleableObjectProperty<Paint>(null) {
         @Override
         public Object getBean() {
@@ -128,6 +162,8 @@ public class TextExt extends Text {
 
         // Add new properties
         styleables.add(StyleableProperties.BACKGROUND_COLOR);
+        styleables.add(StyleableProperties.BACKGROUND_STROKE);
+        styleables.add(StyleableProperties.BACKGROUND_STROKE_WIDTH);
         styleables.add(StyleableProperties.UNDERLINE_COLOR);
         styleables.add(StyleableProperties.UNDERLINE_WIDTH);
         styleables.add(StyleableProperties.UNDERLINE_DASH_ARRAY);
@@ -160,6 +196,51 @@ public class TextExt extends Text {
     public ObjectProperty<Paint> backgroundColorProperty() {
         return backgroundColor;
     }
+
+    public Paint getBackgroundStroke() {
+        return backgroundStroke.get();
+    }
+
+    public void setBackgroundStroke(Paint fill) {
+        backgroundStroke.set(fill);
+    }
+
+    /**
+     * The background stroke color of the section of text.  By default, JavaFX doesn't
+     * support a background for Text (as it is a Shape item), but RichTextFX
+     * does support drawing a different background for different sections of text.
+     *
+     * <p>The background is drawn as a single cohesive shape for pieces of text
+     * with identical backgrounds (by comparing segment styles).  If you have
+     * adjacent pieces of text with different segment styles, the backgrounds will
+     * be drawn separately (even if they have the same resulting colours), so
+     * you will get the stroke drawn at the boundaries between the segments.</p>
+     *
+     * <p>Note that this is actually a Paint type, so you can specify gradient or image fills
+     * rather than a flat colour.  But due to line wrapping, it's possible that
+     * the fill may be used multiple times on separate lines even for the same
+     * segment of text.</p>
+     *
+     * Can be styled from CSS using the "-rtfx-background-stroke" property.
+     */
+    public ObjectProperty<Paint> backgroundStrokeProperty() {
+        return backgroundStroke;
+    }
+
+    // Width of the text underline
+    public Number getBackgroundStrokeWidth() { return backgroundStrokeWidth.get(); }
+    public void setBackgroundStrokeWidth(Number width) { backgroundStrokeWidth.set(width); }
+
+    /**
+     * The width of the background stroke.  The background stroke will only be drawn
+     * if backgroundStrokeProperty() (which determines the color) has a non-null value.
+     * See {@link #backgroundStrokeProperty()} for more details.
+     *
+     * Can be styled from CSS using the "-rtfx-background-stroke-width" property.
+     */
+    public ObjectProperty<Number> backgroundStrokeWidthProperty() { return backgroundStrokeWidth; }
+
+
 
     // Color of the text underline (-fx-underline is already defined by JavaFX)
     public Paint getUnderlineColor() { return underlineColor.get(); }
@@ -245,6 +326,37 @@ public class TextExt extends Text {
             @Override
             public StyleableProperty<Paint> getStyleableProperty(TextExt node) {
                 return node.backgroundColor;
+            }
+        };
+
+        private static final CssMetaData<TextExt, Paint> BACKGROUND_STROKE = new CssMetaData<TextExt, Paint>(
+                "-rtfx-background-stroke",
+                StyleConverter.getPaintConverter(),
+                Color.TRANSPARENT) {
+            @Override
+            public boolean isSettable(TextExt node) {
+                return !node.backgroundStroke.isBound();
+            }
+
+            @Override
+            public StyleableProperty<Paint> getStyleableProperty(TextExt node) {
+                return node.backgroundStroke;
+            }
+        };
+
+        private static final CssMetaData<TextExt, Number> BACKGROUND_STROKE_WIDTH = new CssMetaData<TextExt, Number>(
+                "-rtfx-background-stroke-width",
+                StyleConverter.getSizeConverter(),
+                0) {
+
+            @Override
+            public boolean isSettable(TextExt node) {
+                return !node.backgroundStrokeWidth.isBound();
+            }
+
+            @Override
+            public StyleableProperty<Number> getStyleableProperty(TextExt node) {
+                return node.backgroundStrokeWidth;
             }
         };
 


### PR DESCRIPTION
I wonder if you're interested in adding this feature.  It allows you to use stroke as a highlight for some text, instead of or in addition to background colour.  The main limitation is noted in the docs: adjacent segments with different styles will get their strokes painted separately.  That will make it less useful for some use cases, but if you just have a fairly plain text editor and want to add support for highlighting e.g. find results by drawing around them instead of using a background colour, it's useful.