### PR TITLE
Fixes issue #499: calling getCharacterBoundsOnScreen on a paragraph w…

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -156,7 +156,8 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         PathElement[] rangeShape = getRangeShape(from, to);
 
         // switch out shapes to calculate the bounds on screen
-        List<PathElement> selShape = selectionShape.getElements();
+        // Must take a copy of the list contents, not just a reference:
+        List<PathElement> selShape = new ArrayList<>(selectionShape.getElements());
         selectionShape.getElements().setAll(rangeShape);
         Bounds localBounds = selectionShape.getBoundsInLocal();
         Bounds rangeBoundsOnScreen = selectionShape.localToScreen(localBounds);


### PR DESCRIPTION
…ith selection stops the selection being displayed.

The getCharacterBoundsOnScreen method borrows the selectionShape to do the calculation, but it was only taking a reference to the list beforehand, so the saved "copy" was getting wiped out and thus not restoring the selection properly afterwards.  Simple fix: take copy of the list, not a reference.