### PR TITLE
Speed up test fx tests

### DIFF
--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/InlineCssTextAreaAppTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/InlineCssTextAreaAppTest.java
@@ -5,8 +5,10 @@ import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.input.MouseButton;
 import javafx.stage.Stage;
 import org.fxmisc.richtext.InlineCssTextArea;
+import org.testfx.api.FxRobot;
 import org.testfx.framework.junit.ApplicationTest;
 import org.testfx.service.query.PointQuery;
 
@@ -36,5 +38,25 @@ public class InlineCssTextAreaAppTest extends ApplicationTest {
 
     public final PointQuery firstLineOfArea() {
         return point(area).atPosition(Pos.TOP_LEFT).atOffset(5, 5);
+    }
+
+    public final FxRobot clickOnFirstLine(MouseButton... buttons) {
+        return moveTo(firstLineOfArea()).clickOn(buttons);
+    }
+
+    public final FxRobot leftClickOnFirstLine() {
+        return clickOnFirstLine(MouseButton.PRIMARY);
+    }
+
+    public final FxRobot doubleClickOnFirstLine() {
+        return leftClickOnFirstLine().clickOn(MouseButton.PRIMARY);
+    }
+
+    public final FxRobot tripleClickOnFirstLine() {
+        return doubleClickOnFirstLine().clickOn(MouseButton.PRIMARY);
+    }
+
+    public final FxRobot rightClickOnFirstLine() {
+        return clickOnFirstLine(MouseButton.SECONDARY);
     }
 }

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -28,7 +28,7 @@ public class StyledTextAreaBehaviorTest {
         @Test
         public void clickingSecondaryShowsContextMenu() {
             // when
-            rightClickOn(area);
+            rightClickOnFirstLine();
 
             // then
             assertTrue(area.getContextMenu().isShowing());
@@ -37,8 +37,7 @@ public class StyledTextAreaBehaviorTest {
         @Test
         public void pressingSecondaryShowsContextMenu() {
             // when
-            moveTo(area);
-            press(MouseButton.SECONDARY);
+            rightClickOnFirstLine();
 
             // then
             assertTrue(area.getContextMenu().isShowing());
@@ -47,7 +46,7 @@ public class StyledTextAreaBehaviorTest {
         @Test
         public void pressingPrimaryMouseButtonHidesContextMenu() {
             // given menu is showing
-            rightClickOn(area);
+            rightClickOnFirstLine();
 
             press(MouseButton.PRIMARY);
             assertFalse(area.getContextMenu().isShowing());
@@ -56,7 +55,7 @@ public class StyledTextAreaBehaviorTest {
         @Test
         public void pressingMiddleMouseButtonHidesContextMenu() {
             // given menu is showing
-            rightClickOn(area);
+            rightClickOnFirstLine();
 
             press(MouseButton.MIDDLE);
             assertFalse(area.getContextMenu().isShowing());
@@ -66,7 +65,7 @@ public class StyledTextAreaBehaviorTest {
         @Test
         public void requestingContextMenuViaKeyboardWorksOnWindows() {
             if (WINDOWS_OS) {
-                clickOn(area);
+                leftClickOnFirstLine();
                 push(KeyCode.CONTEXT_MENU);
 
                 assert area.getContextMenu().isShowing();
@@ -104,21 +103,21 @@ public class StyledTextAreaBehaviorTest {
 
             @Test
             public void singleClickingAreaDoesNothing() {
-                clickOn(area);
+                leftClickOnFirstLine();
 
                 assertFalse(area.isFocused());
             }
 
             @Test
             public void doubleClickingAreaDoesNothing() {
-                doubleClickOn(area);
+                doubleClickOnFirstLine();
 
                 assertFalse(area.isFocused());
             }
 
             @Test
             public void tripleClickingAreaDoesNothing() {
-                clickOn(area, MouseButton.PRIMARY).doubleClickOn(MouseButton.PRIMARY);
+                tripleClickOnFirstLine();
 
                 assertFalse(area.isFocused());
             }
@@ -372,8 +371,8 @@ public class StyledTextAreaBehaviorTest {
                 area.clear();
             });
 
-            String userInputtedText = "some user-inputted text";
-            clickOn(area).write(userInputtedText);
+            String userInputtedText = "some text";
+            leftClickOnFirstLine().write(userInputtedText);
 
             assertEquals(userInputtedText, area.getText());
             assertEquals(userInputtedText.length(), area.getCaretPosition());

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/StyledTextAreaBehaviorTest.java
@@ -68,7 +68,7 @@ public class StyledTextAreaBehaviorTest {
                 leftClickOnFirstLine();
                 push(KeyCode.CONTEXT_MENU);
 
-                assert area.getContextMenu().isShowing();
+                assertTrue(area.getContextMenu().isShowing());
             }
         }
 


### PR DESCRIPTION
I noticed that the mouse moves from the center of the area (due to `clickOn(area)`) to the top left portion of the first line and vice versa a couple of times in the test. This causes the test suite to take longer than necessary.

`gradle test` on my machine (I ran `gradle clean` before running the tests):
Before | After (in seconds)
18.975 | 15.514