### PR TITLE
Fix issue 476

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'eclipse'
 
-    version = '0.7.0-M6'
+    version = '1.0.0-SNAPSHOT'
     ext.specificationVersion = '0.7.0'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'eclipse'
 
-    version = '1.0.0-SNAPSHOT'
+    version = '0.7.0-M6'
+    ext.specificationVersion = '0.7.0'
 
     repositories {
         mavenCentral()

--- a/richtextfx-demos/build.gradle
+++ b/richtextfx-demos/build.gradle
@@ -2,6 +2,16 @@ dependencies {
     compile project(":richtextfx")
 }
 
+jar {
+    manifest {
+        attributes(
+            'Specification-Title': 'RichTextFX Demos',
+            'Specification-Version': project.specificationVersion,
+            'Implementation-Title': 'RichTextFX Demos',
+            'Implementation-Version': project.version)
+    }
+}
+
 task fatJar(type: Jar, dependsOn: classes) {
     appendix = 'fat'
     from sourceSets.main.output

--- a/richtextfx/build.gradle
+++ b/richtextfx/build.gradle
@@ -37,6 +37,17 @@ dependencies {
     integrationTestCompile "org.testfx:openjfx-monocle:8u76-b04"
 }
 
+
+jar {
+    manifest {
+        attributes(
+            'Specification-Title': 'RichTextFX',
+            'Specification-Version': project.specificationVersion,
+            'Implementation-Title': 'RichTextFX',
+            'Implementation-Version': project.version)
+    }
+}
+
 javadoc {
     // ignore missing Javadoc comments or tags
     options.addStringOption('Xdoclint:all,-missing', '-quiet')


### PR DESCRIPTION
Manifest files were added to the RichTextFX libraries. Implementation and specification version were set to 0.7.0-M6 and 0.7.0 respectively. See http://semver.org.

Note that the version information must be updated manually. They also might be derived from Git tags
using Gradle plugins like https://github.com/palantir/gradle-git-version.