### PR TITLE
Add debug flag to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 
 script:
   - gradle assemble
-  - gradle check --stacktrace
+  - gradle check --debug --stacktrace
 
 # See https://docs.travis-ci.com/user/languages/java/#Caching
 before_cache:


### PR DESCRIPTION
re-adds the debug flag to travis so we can see why tests fail. In particular, which test in the `integrationTest` suite fails and why (time out?).