### PR TITLE
Allow UndoManager to use developer-defined changes (text, view, etc.)

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/UndoActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/UndoActions.java
@@ -13,7 +13,7 @@ public interface UndoActions {
      * Undo manager of this text area.
      */
     UndoManager getUndoManager();
-    void setUndoManager(UndoManagerFactory undoManagerFactory);
+    void setUndoManager(UndoManager undoManager);
 
     default void undo() { getUndoManager().undo(); }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/util/UndoUtils.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/util/UndoUtils.java
@@ -1,0 +1,43 @@
+package org.fxmisc.richtext.util;
+
+import org.fxmisc.richtext.GenericStyledArea;
+import org.fxmisc.richtext.model.PlainTextChange;
+import org.fxmisc.richtext.model.RichTextChange;
+import org.fxmisc.richtext.model.TextChange;
+import org.fxmisc.undo.UndoManager;
+import org.fxmisc.undo.UndoManagerFactory;
+
+import java.util.function.Consumer;
+
+public final class UndoUtils {
+
+    private UndoUtils() {
+        throw new IllegalStateException("UndoUtils cannot be instantiated");
+    }
+
+    public static <PS, SEG, S> UndoManager createUndoManager(GenericStyledArea<PS, SEG, S> area) {
+        return area.isPreserveStyle()
+                ? richTextUndoManager(area)
+                : plainTextUndoManager(area);
+    }
+
+    public static <PS, SEG, S> UndoManager richTextUndoManager(GenericStyledArea<PS, SEG, S> area) {
+        return richTextUndoManager(area, UndoManagerFactory.unlimitedHistoryFactory());
+    }
+
+    public static <PS, SEG, S> UndoManager richTextUndoManager(GenericStyledArea<PS, SEG, S> area,
+                                                               UndoManagerFactory factory) {
+        Consumer<RichTextChange<PS, SEG, S>> apply = change -> area.replace(change.getPosition(), change.getPosition() + change.getRemoved().length(), change.getInserted());
+        return factory.create(area.richChanges(), RichTextChange::invert, apply, TextChange::mergeWith, TextChange::isIdentity);
+    };
+
+    public static <PS, SEG, S> UndoManager plainTextUndoManager(GenericStyledArea<PS, SEG, S> area) {
+        return plainTextUndoManager(area, UndoManagerFactory.unlimitedHistoryFactory());
+    }
+
+    public static <PS, SEG, S> UndoManager plainTextUndoManager(GenericStyledArea<PS, SEG, S> area,
+                                                                UndoManagerFactory factory) {
+        Consumer<PlainTextChange> apply = change -> area.replaceText(change.getPosition(), change.getPosition() + change.getRemoved().length(), change.getInserted());
+        return factory.create(area.plainTextChanges(), PlainTextChange::invert, apply, TextChange::mergeWith, TextChange::isIdentity);
+    }
+}


### PR DESCRIPTION
Addresses #333 

One cannot pass in an `UndoManager` as an argument since its `apply` Consumer requires the area to already be constructed. As such, the area still constructs the default `UndoManager`. However, once the area is constructed, this PR now allows one to set the area's undoManager directly and not indirectly through an `UndoManagerFactory`. 
Thus, one has complete control over how the `UndoManager` is constructed and functions. It could only handle changes to the area's text, only changes to the area's view, or something else altogether.

Future PRs could add other factory methods for constructing `UndoManager`s that work differently.