### PR TITLE
Stop next change from merging with previous one after inactive period.

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/view/MiscellaneousAPITests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/view/MiscellaneousAPITests.java
@@ -9,6 +9,7 @@ import javafx.stage.Stage;
 import org.fxmisc.richtext.Caret;
 import org.fxmisc.richtext.InlineCssTextAreaAppTest;
 import org.fxmisc.richtext.model.NavigationActions;
+import org.fxmisc.richtext.util.UndoUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/view/UndoManagerTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/view/UndoManagerTests.java
@@ -1,0 +1,28 @@
+package org.fxmisc.richtext.view;
+
+import org.fxmisc.richtext.InlineCssTextAreaAppTest;
+import org.fxmisc.richtext.util.UndoUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UndoManagerTests extends InlineCssTextAreaAppTest {
+
+    @Test
+    public void preventMergeOfIncomingChangeAfterPeriodOfUserInactivity() {
+        String text1 = "text1";
+        String text2 = "text2";
+
+        long periodOfUserInactivity = UndoUtils.DEFAULT_PREVENT_MERGE_DELAY.toMillis() + 300L;
+
+        write(text1);
+        sleep(periodOfUserInactivity);
+        write(text2);
+
+        interact(area::undo);
+        assertEquals(text1, area.getText());
+
+        interact(area::undo);
+        assertEquals("", area.getText());
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/util/UndoManagerInactivityWrapper.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/util/UndoManagerInactivityWrapper.java
@@ -1,0 +1,129 @@
+package org.fxmisc.richtext.util;
+
+import javafx.beans.value.ObservableBooleanValue;
+import org.fxmisc.undo.UndoManager;
+import org.reactfx.EventStream;
+import org.reactfx.Subscription;
+import org.reactfx.value.Val;
+
+import java.time.Duration;
+
+/**
+ * A wrapper around an {@link UndoManager} that prevents the next emitted change from merging with the previous
+ * one after a period of inactivity (i.e., the UndoManager's {@code changeSource} has not emitted an event
+ * after a specified period of time.
+ *
+ * @param <C> the type of change the UndoManager can undo/redo
+ */
+final class UndoManagerInactivityWrapper<C> implements UndoManager<C> {
+
+    private final UndoManager<C> delegate;
+    private final Subscription subscription;
+
+    /**
+     * Wraps an {@link UndoManager} and prevents the next emitted change from merging with the previous one
+     * after a period of inactivity (i.e., the {@code changeSource} has not emitted an event for
+     * {@code preventMergeDelay}). <b>Note:</b> there is no check that insures that the {@code changeSource}
+     * parameter is the same one used by the {@code undoManager} parameter
+     */
+    public UndoManagerInactivityWrapper(UndoManager<C> undoManager, EventStream<C> changeSource, Duration preventMergeDelay) {
+        this.delegate = undoManager;
+        subscription = changeSource.successionEnds(preventMergeDelay).subscribe(ignore -> preventMerge());
+    }
+
+    @Override
+    public boolean undo() {
+        return delegate.undo();
+    }
+
+    @Override
+    public boolean redo() {
+        return delegate.redo();
+    }
+
+    @Override
+    public Val<Boolean> undoAvailableProperty() {
+        return delegate.undoAvailableProperty();
+    }
+
+    @Override
+    public boolean isUndoAvailable() {
+        return delegate.isUndoAvailable();
+    }
+
+    @Override
+    public Val<C> nextToUndoProperty() {
+        return delegate.nextToUndoProperty();
+    }
+
+    @Override
+    public C getNextToUndo() {
+        return delegate.getNextToUndo();
+    }
+
+    @Override
+    public Val<C> nextToRedoProperty() {
+        return delegate.nextToRedoProperty();
+    }
+
+    @Override
+    public C getNextToRedo() {
+        return delegate.getNextToRedo();
+    }
+
+    @Override
+    public Val<Boolean> redoAvailableProperty() {
+        return delegate.redoAvailableProperty();
+    }
+
+    @Override
+    public boolean isRedoAvailable() {
+        return delegate.isRedoAvailable();
+    }
+
+    @Override
+    public ObservableBooleanValue performingActionProperty() {
+        return delegate.performingActionProperty();
+    }
+
+    @Override
+    public boolean isPerformingAction() {
+        return delegate.isPerformingAction();
+    }
+
+    @Override
+    public void preventMerge() {
+        delegate.preventMerge();
+    }
+
+    @Override
+    public void forgetHistory() {
+        delegate.forgetHistory();
+    }
+
+    @Override
+    public UndoPosition getCurrentPosition() {
+        return delegate.getCurrentPosition();
+    }
+
+    @Override
+    public void mark() {
+        delegate.mark();
+    }
+
+    @Override
+    public ObservableBooleanValue atMarkedPositionProperty() {
+        return delegate.atMarkedPositionProperty();
+    }
+
+    @Override
+    public boolean isAtMarkedPosition() {
+        return delegate.isAtMarkedPosition();
+    }
+
+    @Override
+    public void close() {
+        subscription.unsubscribe();
+        delegate.close();
+    }
+}


### PR DESCRIPTION
Addresses #362.

This should really be changed in UndoFX. But since that won't have a new release in the foreseeable future, this can bring the same functionality until such a release exists.