### PR TITLE
Added BlueJ to the list of projects using RichTextFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Who uses RichTextFX?
 - [Markdown Writer FX](https://github.com/JFormDesigner/markdown-writer-fx)
 - [OmniEditor](https://github.com/giancosta86/OmniEditor), which is then used by [Chronos IDE](https://github.com/giancosta86/Chronos-IDE)
 - [JuliarFuture](https://juliar.org)
+- [BlueJ](https://www.bluej.org/)
 
 If you use RichTextFX in an interesting project, I would like to know!
 


### PR DESCRIPTION
We've just released the latest version of BlueJ, which now uses RichTextFX.   BlueJ is an educational IDE for Java. We have in the order of 300,000 users a month, so RichTextFX will be in use by a lot of people.

Just wanted to say thanks for the library: we used to use Swing's JEditorPane, but for various reasons (HiDPI support, SwingNode bugs) we needed to transition to JavaFX.  We had previously held off because there was no good in-built JavaFX component for text editing, so finding RichTextFX was a real bonus for us.  It was flexible enough that we were able to bend it to do what we needed, including our scope highlighting (see below).  So: thanks!

Here's a shot of our RichTextFX-backed editor:

![image](https://user-images.githubusercontent.com/2347447/27488558-5f00dc8a-582f-11e7-865c-e3be7f93a191.png)
