### PR TITLE
Optimize background color and underline shapes

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -98,6 +98,10 @@ class TextFlowExt extends TextFlow {
         return textLayout().getRange(from, to, TextLayout.TYPE_TEXT, 0, 0);
     }
 
+    PathElement[] getUnderlineShape(IndexRange range) {
+        return getUnderlineShape(range.getStart(), range.getEnd());
+    }
+
     /**
      * @param from The index of the first character.
      * @param to The index of the last character.

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import javafx.scene.control.IndexRange;
 import org.fxmisc.richtext.model.TwoLevelNavigator;
 
 import javafx.scene.shape.PathElement;
@@ -87,6 +88,10 @@ class TextFlowExt extends TextFlow {
 
     PathElement[] getCaretShape(int charIdx, boolean isLeading) {
         return textLayout().getCaretShape(charIdx, isLeading, 0.0f, 0.0f);
+    }
+
+    PathElement[] getRangeShape(IndexRange range) {
+        return getRangeShape(range.getStart(), range.getEnd());
     }
 
     PathElement[] getRangeShape(int from, int to) {


### PR DESCRIPTION
Only uses 1 shape for a value (background, underline) shared between multiple consecutive TextExt segments.

This provides the needed support to quickly implement #346 without the adjacent segments issue.