### PR TITLE
Enhancement: Selecting a newline char selects the rest of the line

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -878,7 +878,8 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     }
 
     /**
-     * Returns the selection range in the given paragraph.
+     * Returns the selection range in the given paragraph. Note: this method will return
+     * {@code IndexRange(start, paragraph.length() + 1)} when the selection includes a newline character.
      */
     public IndexRange getParagraphSelection(int paragraph) {
         return getParagraphSelection(caretSelectionBind, paragraph);
@@ -893,7 +894,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         }
 
         int start = paragraph == startPar ? selection.getStartColumnPosition() : 0;
-        int end = paragraph == endPar ? selection.getEndColumnPosition() : getParagraphLength(paragraph);
+        int end = paragraph == endPar ? selection.getEndColumnPosition() : getParagraphLength(paragraph) + 1;
 
         // force rangeProperty() to be valid
         selection.getRange();


### PR DESCRIPTION
Resolves #549 according to the IntelliJ style

Note: this PR should be refactored because `getParagraphSelection` now returns `IndexRange(start, paragraph.length() + 1)` in some cases.

I'd like to say that there should be two separate methods: one for getting just the range inside the paragraph and another that adds one if it includes the newline character. 