### PR TITLE
fixed caret positioning in wrapped lines (issue #423)

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/keyboard/NavigationTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/keyboard/NavigationTests.java
@@ -225,7 +225,7 @@ public class NavigationTests {
 
     }
 
-    public class MultiLineTests extends InlineCssTextAreaAppTest {
+    public class MultiLineGridlikeTextTests extends InlineCssTextAreaAppTest {
 
         public final String[] lines = {
                 "01 02 03 04 05",
@@ -494,6 +494,53 @@ public class NavigationTests {
 
         }
 
+    }
+
+    public class MultiLineJaggedTextTests extends InlineCssTextAreaAppTest {
+
+        String threeLinesOfText = "Some long amount of text to take up a lot of space in the given area.";
+
+        @Override
+        public void start(Stage stage) throws Exception {
+            super.start(stage);
+            stage.setWidth(200);
+            area.replaceText(threeLinesOfText);
+            area.setWrapText(true);
+        }
+
+        private void waitForMultiLineRegistration() throws TimeoutException {
+            // When the stage's width changes, TextFlow does not properly handle API calls to a
+            //  multi-line paragraph immediately. So, wait until it correctly responds
+            //  to the stage width change
+            Future<Void> textFlowIsReady = WaitForAsyncUtils.asyncFx(() -> {
+                while (area.getParagraphLinesCount(0) != 3) {
+                    sleep(10);
+                }
+            });
+            WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, textFlowIsReady);
+        }
+
+        @Test
+        public void pressingDownMovesCaretToNextLine() throws TimeoutException {
+            waitForMultiLineRegistration();
+
+            area.moveTo(27);
+
+            push(DOWN);
+
+            assertEquals(57, area.getCaretPosition());
+        }
+
+        @Test
+        public void pressingUpMovesCaretToPrevLine() throws TimeoutException {
+            waitForMultiLineRegistration();
+
+            area.moveTo(66);
+
+            push(UP);
+
+            assertEquals(36, area.getCaretPosition());
+        }
     }
 
     public class ViewportTests extends InlineCssTextAreaAppTest {


### PR DESCRIPTION
This PR fixes some issues with caret positioning in **wrapped lines**:

1) pressing `DOWN` key at end of line now moves caret to end of next line (and not beginning of line after next line).
E.g. if caret is at `|` then `DOWN` key moves it to `^` (and not `*` as before).
~~~
01234|
678^
*01
~~~

2) `UP` key now always works as expected (and no longer "locks" at `*` as before)

3) when clicking with the mouse after text in a wrapped line (e.g. right to `^`), then the caret is now positioned at the end of the hit line (and not at the beginning of the next line as before)

Here is some code to reproduce:
~~~java
import javafx.application.Application;
import javafx.scene.Scene;
import javafx.stage.Stage;
import org.fxmisc.flowless.VirtualizedScrollPane;
import org.fxmisc.richtext.InlineCssTextArea;

public class HitWrappedBug extends Application {

    @Override
    public void start(Stage primaryStage) throws Exception {
        InlineCssTextArea area = new InlineCssTextArea("01234 678 01");
        area.setWrapText(true);
        area.setStyle("-fx-font-size: 30pt");
        VirtualizedScrollPane<InlineCssTextArea> vsPane = new VirtualizedScrollPane<>(area);

        Scene scene = new Scene(vsPane, 50, 400);
        primaryStage.setScene(scene);
        primaryStage.show();
    }
}
~~~

I think this fixes #423