### PR TITLE
fix selection painting of empty lines if text area displays line numbers

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -270,7 +270,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
             // Selection includes a newline character.
             if (paragraph.length() == 0) {
                 // empty paragraph
-                shape = createRectangle(getLayoutX(), getLayoutY(), getWidth(), getHeight());
+                shape = createRectangle(0, 0, getWidth(), getHeight());
             } else if (start == paragraph.length()) {
                 // selecting only the newline char
 


### PR DESCRIPTION
It the text area displays line numbers, then the selection of empty lines is not displayed correctly.

![image](https://user-images.githubusercontent.com/12702749/30136147-e438d592-935d-11e7-877f-6960f02165a3.png)

This PR fixes this.
