### PR TITLE
select moved text after drag-and-drop

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
@@ -132,6 +132,7 @@ public class ClickAndDragTests {
 
             private String firstWord = "Some";
             private String firstParagraph = firstWord + " text goes here";
+            private String extraText = "This is extra text";
 
             @Test
             public void singleClickingWithinSelectedTextMovesCaretToThatPosition() {
@@ -238,18 +239,17 @@ public class ClickAndDragTests {
             public void pressingMouseOnSelectionAndDraggingDisplacesCaret() {
                 // setup
                 interact(() -> {
-                    area.replaceText(firstParagraph + "\n" + "This is extra text");
+                    area.replaceText(firstParagraph + "\n" + extraText);
                     area.selectRange(0, firstWord.length());
                 });
 
                 String selText = area.getSelectedText();
-                int caretPos = area.getCaretPosition();
 
                 moveTo(firstLineOfArea())
                         .press(PRIMARY)
-                        .moveBy(0, 14);
+                        .moveBy(0, 22);
 
-                assertTrue(caretPos != area.getCaretPosition());
+                assertEquals(firstParagraph.length() + 1, area.getCaretPosition());
                 assertEquals(selText, area.getSelectedText());
             }
 
@@ -257,19 +257,22 @@ public class ClickAndDragTests {
             public void pressingMouseOnSelectionAndDraggingAndReleasingMovesSelectedTextToThatPosition() {
                 // setup
                 interact(() -> {
-                    area.replaceText(firstParagraph + "\n" + "This is extra text");
+                    area.replaceText(firstParagraph + "\n" + extraText);
                     area.selectRange(0, firstWord.length());
                 });
 
                 String selText = area.getSelectedText();
-                int caretPos = area.getCaretPosition();
 
                 moveTo(firstLineOfArea())
                         .press(PRIMARY)
-                        .dropBy(0, 14);
+                        .dropBy(0, 22);
 
-                assertTrue(caretPos != area.getCaretPosition());
+                String expectedText = firstParagraph.substring(firstWord.length())
+                    + "\n" + firstWord + extraText;
+
+                assertEquals(firstParagraph.length() + 1, area.getCaretPosition());
                 assertEquals(selText, area.getSelectedText());
+                assertEquals(expectedText, area.getText());
             }
 
         }

--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
@@ -261,6 +261,7 @@ public class ClickAndDragTests {
                     area.selectRange(0, firstWord.length());
                 });
 
+                String selText = area.getSelectedText();
                 int caretPos = area.getCaretPosition();
 
                 moveTo(firstLineOfArea())
@@ -268,7 +269,7 @@ public class ClickAndDragTests {
                         .dropBy(0, 14);
 
                 assertTrue(caretPos != area.getCaretPosition());
-                assertTrue(area.getSelectedText().isEmpty());
+                assertEquals(selText, area.getSelectedText());
             }
 
         }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/EditActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/EditActions.java
@@ -186,6 +186,9 @@ public interface EditActions<PS, SEG, S> extends TextEditingArea<PS, SEG, S> {
                 pos -= sel.getLength();
             deleteText(sel);
             insert(pos, text);
+
+            // select moved text
+            selectRange(pos, pos + text.length());
         }
     }
 }


### PR DESCRIPTION
When doing drag-and-drop then the moved text was not selected (as in other text editors).