### PR TITLE
adjust wrapped lines selection to the rest of the line

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -294,6 +294,19 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
                 shape[bottomRightIndex] = new LineTo(getWidth(), getHeight());
             }
         }
+
+        if (getLineCount() > 1) {
+            // adjust right corners of wrapped lines
+            boolean wrappedAtEndPos = (end > 0 && getLineOfCharacter(end) > getLineOfCharacter(end - 1));
+            int adjustLength = shape.length - (wrappedAtEndPos ? 0 : 5);
+            for (int i = 0; i < adjustLength; i++) {
+                if (shape[i] instanceof MoveTo) {
+                    ((LineTo)shape[i + 1]).setX(getWidth());
+                    ((LineTo)shape[i + 2]).setX(getWidth());
+                }
+            }
+        }
+
         return shape;
     }
 
@@ -302,7 +315,8 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
                 new MoveTo(topLeftX, topLeftY),
                 new LineTo(bottomRightX, topLeftY),
                 new LineTo(bottomRightX, bottomRightY),
-                new LineTo(topLeftX, bottomRightY)
+                new LineTo(topLeftX, bottomRightY),
+                new LineTo(topLeftX, topLeftY)
         };
     }
 


### PR DESCRIPTION
Adjust right edge of wrapped lines selection to the rest of the line (similar to #549 / #564). IOW when selection the space character at the end of a wrapped line, then the selection is expanded to the right edge of the text area.

Old:
("01234 678 01" is a single line)

![image](https://user-images.githubusercontent.com/12702749/30159245-3d1da59c-93c8-11e7-80b1-1aa97008b7db.png) ![image](https://user-images.githubusercontent.com/12702749/30159220-2c0397bc-93c8-11e7-9b88-f991ee2466a0.png)

New:

![image](https://user-images.githubusercontent.com/12702749/30159042-95ca41e2-93c7-11e7-99d5-b09d3cfd1c74.png) ![image](https://user-images.githubusercontent.com/12702749/30159192-17ed5650-93c8-11e7-81d8-137df0f93ed0.png)



Also closed rectangle path in `ParagraphText.createRectangle()`. Not sure whether this makes any difference, but `com.sun.javafx.text.PrismTextLayout.getRange()` does it too. So there might be a reason...